### PR TITLE
Added references to GS.Shared resource dictionaries to App.Xaml

### DIFF
--- a/GS.Server/App.xaml
+++ b/GS.Server/App.xaml
@@ -40,7 +40,12 @@
 
                 <!--Also add the base theme, this is required always-->
                 <ResourceDictionary Source="pack://application:,,,/LiveCharts.Wpf;component/Themes/base.xaml" />
-            </ResourceDictionary.MergedDictionaries>
+
+               <!-- Add resources from GS.Shared so that they are available at design time -->
+            <ResourceDictionary Source="pack://application:,,,/GS.Shared;component/Languages/StringResChart_en-us.xaml"/>
+            <ResourceDictionary Source="pack://application:,,,/GS.Shared;component/Languages/StringResServer_en-us.xaml"/>
+            <ResourceDictionary Source="pack://application:,,,/GS.Shared;component/Languages/StringResUtil_en-us.xaml"/>
+         </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>
 </Application>


### PR DESCRIPTION
Hi Rob,

By way of a small test of how pull requests work I have forked the repository so I have my own copy to work on. I have made a small change adding the language resource dictionaries in GS.Shared as MergedDictionaries in App.xaml. This allows the designer to find the resources at design time.

[Update] Still learning how to use GIT other than as an sole developer! I think I should have created a branch to do the bigger change then I may have been all to create a separate pull request. As it is I have also code to fix the Dec short fall when performing a GoTo.

I have pulled your RA axis precision slew code out into a method of it's own and added a similar method for the Dec axis. Both methods are then called in parallel from SkyGoTo.

If I remember correctly EQASCOM does a final tweak on both axes which is probably why I have never had a problem with that. It may well be that there is a glitch in the AstroEQ firmware which hasn't been picked up over the years because everyone with an AstroEQ will probably be using EQASCOM anyway.

Phil