### PR TITLE
Reduced load on CPU and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+[Bb]uilds/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/GS.FitsImageManager/GS.FitsImageManager.csproj
+++ b/GS.FitsImageManager/GS.FitsImageManager.csproj
@@ -42,6 +42,6 @@
     </None>
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="IF &quot;$(PlatformName)&quot; == &quot;x64&quot; ECHO f | COPY /Y &quot;$(ProjectDir)cfitsio\cfitsio_64.dll&quot; &quot;$(TargetDir)cfitsio.dll&quot;&#xD;&#xA;IF NOT &quot;$(PlatformName)&quot; == &quot;x64&quot; ECHO f | COPY /Y &quot;$(ProjectDir)cfitsio\cfitsio_32.dll&quot; &quot;$(TargetDir)cfitsio.dll&quot;&#xD;&#xA;XCOPY /Y &quot;$(TargetPath)&quot; &quot;$(ProjectDir)..\Builds\&quot;" />
+    <Exec Command="IF &quot;$(PlatformName)&quot; == &quot;x64&quot; ECHO f | COPY /Y &quot;$(ProjectDir)cfitsio\cfitsio_64.dll&quot; &quot;$(TargetDir)cfitsio.dll&quot;&#xD;&#xA;IF NOT &quot;$(PlatformName)&quot; == &quot;x64&quot; ECHO f | COPY /Y &quot;$(ProjectDir)cfitsio\cfitsio_32.dll&quot; &quot;$(TargetDir)cfitsio.dll&quot;" />
   </Target>
 </Project>

--- a/GS.Server/Alignment/AlignmentVM.cs
+++ b/GS.Server/Alignment/AlignmentVM.cs
@@ -67,9 +67,10 @@ namespace GS.Server.Alignment
             if (_skyTelescopeVM == null) _skyTelescopeVM = SkyTelescopeVM._skyTelescopeVM;
 
             BindingOperations.EnableCollectionSynchronization(AlignmentPoints, _alignmentPointsLock);
+            SkyServer.AlignmentModel.AlignmentPoints.CollectionChanged += AlignmentPoints_CollectionChanged;
 
-            WeakEventManager<AlignmentPointCollection, NotifyCollectionChangedEventArgs>.AddHandler(SkyServer.AlignmentModel.AlignmentPoints, "CollectionChanged", AlignmentPoints_CollectionChanged);
         }
+
 
         private void AlignmentPoints_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {

--- a/GS.Server/SkyTelescope/SkyServer.cs
+++ b/GS.Server/SkyTelescope/SkyServer.cs
@@ -123,7 +123,6 @@ namespace GS.Server.SkyTelescope
                 };
                 AlignmentModel.SetHomePosition(_homeAxes.X, _homeAxes.Y);
                 AlignmentModel.Notification += AlignmentModel_Notification;
-                WeakEventManager<AlignmentModel, NotificationEventArgs>.AddHandler(AlignmentModel, "Notification", AlignmentModel_Notification);
 
                 // attach handler to watch for SkySettings changing.
                 SkySettings.StaticPropertyChanged += PropertyChangedSkySettings;
@@ -4395,24 +4394,7 @@ namespace GS.Server.SkyTelescope
         /// <returns></returns>
         private static double[] GetAdjustAxesForReporting(double[] actualAxes)
         {
-            var calculatedAxes = AlignmentModel.GetMountAxes(actualAxes, (int)SideOfPier);
-            if (AlignmentModel.IsAlignmentOn)
-            {
-                var monitorItem = new MonitorEntry
-                {
-                    Datetime = HiResDateTime.UtcNow,
-                    Device = MonitorDevice.Telescope,
-                    Category = MonitorCategory.Alignment,
-                    Type = MonitorType.Information,
-                    Method = MethodBase.GetCurrentMethod().Name,
-                    Thread = Thread.CurrentThread.ManagedThreadId,
-                    Message =
-                        $"Alignment applied to raw axes: {actualAxes[0]},{actualAxes[1]} -> {calculatedAxes[0]},{calculatedAxes[1]}"
-                };
-                MonitorLog.LogToMonitor(monitorItem);
-            }
-
-            return calculatedAxes;
+            return AlignmentModel.GetMountAxes(actualAxes, (int)SideOfPier);
         }
 
         #endregion

--- a/NStarAlignment/Model/AlignmentModel.cs
+++ b/NStarAlignment/Model/AlignmentModel.cs
@@ -288,5 +288,6 @@ namespace NStarAlignment.Model
             _stringBuilder.Clear();
         }
 
+
     }
 }

--- a/NStarAlignment/Model/AlignmentModel_Goto.cs
+++ b/NStarAlignment/Model/AlignmentModel_Goto.cs
@@ -166,7 +166,6 @@ namespace NStarAlignment.Model
 
             lock (_accessLock)
             {
-                ClearSelectedPoints();
                 AxisPosition sAxes = new AxisPosition(observedAxes);
                 if (sAxes.IncludedAngleTo(_homePosition) < ProximityLimit) return observedAxes;    // Fast exit if we are going home.
                 RaiseNotification(NotificationType.Information, $"GetMountAxes for {observedAxes[0]}/{observedAxes[1]}");
@@ -186,6 +185,7 @@ namespace NStarAlignment.Model
                     }
                     else
                     {
+                        ClearSelectedPoints();
                         offsets[0, 0] = AlignmentPoints[0].MountAxes[0] - AlignmentPoints[0].ObservedAxes[0];
                         offsets[0, 1] = AlignmentPoints[0].MountAxes[1] - AlignmentPoints[0].ObservedAxes[1];
                         AlignmentPoints[0].Selected = true;
@@ -209,9 +209,9 @@ namespace NStarAlignment.Model
                     else
                     {
                         int rows = alignmentPoints.Length;
-
                         if (rows > 2)
                         {
+                            ClearSelectedPoints();
                             // Build features and values from registered points
                             Matrix features = Matrix.CreateInstance(rows, 3);
                             Matrix values = Matrix.CreateInstance(rows, 2);
@@ -273,6 +273,7 @@ namespace NStarAlignment.Model
                             }
                             else
                             {
+                                ClearSelectedPoints();
                                 // Use the nearest point of the two.
                                 offsets[0, 0] = alignmentPoints[0].MountAxes[0] - alignmentPoints[0].ObservedAxes[0];
                                 offsets[0, 1] = alignmentPoints[0].MountAxes[1] - alignmentPoints[0].ObservedAxes[1];

--- a/NStarAlignment/Model/AlignmentModel_Goto.cs
+++ b/NStarAlignment/Model/AlignmentModel_Goto.cs
@@ -24,6 +24,19 @@ namespace NStarAlignment.Model
 {
     public partial class AlignmentModel
     {
+        /// <summary>
+        /// Checksum used as a quick to see if the seleted points have changed
+        /// </summary>
+        private int _currentChecksum = int.MinValue;
+
+        /// <summary>
+        /// The cached offsets linked with the current checksum 
+        /// </summary>
+        private Matrix _lastOffsets = Matrix.CreateInstance(1, 2);
+
+        /// <summary>
+        /// List of selected alignment points.
+        /// </summary>
         private readonly List<AlignmentPoint> _selectedPoints = new List<AlignmentPoint>();
 
 
@@ -47,7 +60,6 @@ namespace NStarAlignment.Model
                 RaiseNotification(NotificationType.Information, $"GetObservedAxes for {mountAxes[0]}/{mountAxes[1]}");
                 PierSide pSide = (PierSide)pierSide;
                 WriteLastAccessTime();
-
                 Matrix offsets = Matrix.CreateInstance(1, 2);
                 if (AlignmentPoints.Count == 1)
                 {
@@ -59,8 +71,7 @@ namespace NStarAlignment.Model
                 }
                 else
                 {
-                    IEnumerable<AlignmentPoint> nearestPoints = GetNearestMountPoints(mAxes, pSide, SampleSize);
-                    var alignmentPoints = nearestPoints as AlignmentPoint[] ?? nearestPoints.ToArray();
+                    AlignmentPoint[] alignmentPoints = GetNearestMountPoints(mAxes, pSide, SampleSize);
                     int rows = alignmentPoints.Length;
 
                     if (rows > 2)
@@ -163,78 +174,119 @@ namespace NStarAlignment.Model
                 PierSide pSide = (PierSide)pierSide;
                 WriteLastAccessTime();
                 Matrix offsets = Matrix.CreateInstance(1, 2);
+                int checksum;
+
                 if (AlignmentPoints.Count == 1)
                 {
-                    offsets[0, 0] = AlignmentPoints[0].MountAxes[0] - AlignmentPoints[0].ObservedAxes[0];
-                    offsets[0, 1] = AlignmentPoints[0].MountAxes[1] - AlignmentPoints[0].ObservedAxes[1];
-                    AlignmentPoints[0].Selected = true;
-                    _selectedPoints.Add(AlignmentPoints[0]);
-                    RaiseNotification(NotificationType.Data, $"Single alignment point selected {AlignmentPoints[0].Id:D3}, Mount axes: {AlignmentPoints[0].MountAxes.RaAxis}/{AlignmentPoints[0].MountAxes.RaAxis}, Observed axes: {AlignmentPoints[0].ObservedAxes.RaAxis}/{AlignmentPoints[0].ObservedAxes.RaAxis}");
+                    checksum = GetChecksum(AlignmentPoints[0].Id);
+                    if (checksum == _currentChecksum)
+                    {
+                        // Checksum hasn't changed so use the last offsets
+                        offsets = _lastOffsets;
+                    }
+                    else
+                    {
+                        offsets[0, 0] = AlignmentPoints[0].MountAxes[0] - AlignmentPoints[0].ObservedAxes[0];
+                        offsets[0, 1] = AlignmentPoints[0].MountAxes[1] - AlignmentPoints[0].ObservedAxes[1];
+                        AlignmentPoints[0].Selected = true;
+                        _selectedPoints.Add(AlignmentPoints[0]);
+                        // Cache the offsets and checksum
+                        _lastOffsets = offsets;
+                        _currentChecksum = checksum;
+                        RaiseNotification(NotificationType.Data,
+                            $"Single alignment point selected {AlignmentPoints[0].Id:D3}, Mount axes: {AlignmentPoints[0].MountAxes.RaAxis}/{AlignmentPoints[0].MountAxes.RaAxis}, Observed axes: {AlignmentPoints[0].ObservedAxes.RaAxis}/{AlignmentPoints[0].ObservedAxes.RaAxis}");
+                    }
                 }
                 else
                 {
-                    IEnumerable<AlignmentPoint> nearestPoints = GetNearestObservedPoints(sAxes, pSide, SampleSize);
-                    var alignmentPoints = nearestPoints as AlignmentPoint[] ?? nearestPoints.ToArray();
-                    int rows = alignmentPoints.Length;
-
-                    if (rows > 2)
+                    // Get the nearest points and their corresponding checksum value
+                    AlignmentPoint[] alignmentPoints = GetNearestObservedPoints(sAxes, pSide, SampleSize, out checksum);
+                    if (checksum == _currentChecksum)
                     {
-                        // Build features and values from registered points
-                        Matrix features = Matrix.CreateInstance(rows, 3);
-                        Matrix values = Matrix.CreateInstance(rows, 2);
-                        _stringBuilder.Clear();
-                        _stringBuilder.Append("Points chosen are");
-                        for (int i = 0; i < rows; i++)
+                        // Checksum hasn't changed to use the last offsets
+                        offsets = _lastOffsets;
+                    }
+                    else
+                    {
+                        int rows = alignmentPoints.Length;
+
+                        if (rows > 2)
                         {
-                            var pt = alignmentPoints[i];
-                            _stringBuilder.Append($" ({pt.Id:D3})");
-                            features[i, 0] = 1f;
-                            features[i, 1] = pt.ObservedAxes[0] * pt.ObservedAxes[0];
-                            features[i, 2] = pt.ObservedAxes[1] * pt.ObservedAxes[1];
-                            values[i, 0] = Range.RangePlusOrMinus180(pt.MountAxes[0] - pt.ObservedAxes[0]);
-                            values[i, 1] = Range.RangePlusOrMinus180(pt.MountAxes[1] - pt.ObservedAxes[1]);
-                            pt.Selected = true;
-                            _selectedPoints.Add(pt);
+                            // Build features and values from registered points
+                            Matrix features = Matrix.CreateInstance(rows, 3);
+                            Matrix values = Matrix.CreateInstance(rows, 2);
+                            _stringBuilder.Clear();
+                            _stringBuilder.Append("Points chosen are");
+                            for (int i = 0; i < rows; i++)
+                            {
+                                var pt = alignmentPoints[i];
+                                _stringBuilder.Append($" ({pt.Id:D3})");
+                                features[i, 0] = 1f;
+                                features[i, 1] = pt.ObservedAxes[0] * pt.ObservedAxes[0];
+                                features[i, 2] = pt.ObservedAxes[1] * pt.ObservedAxes[1];
+                                values[i, 0] = Range.RangePlusOrMinus180(pt.MountAxes[0] - pt.ObservedAxes[0]);
+                                values[i, 1] = Range.RangePlusOrMinus180(pt.MountAxes[1] - pt.ObservedAxes[1]);
+                                pt.Selected = true;
+                                _selectedPoints.Add(pt);
+                            }
+
+                            _stringBuilder.AppendLine(".");
+
+
+
+                            // Solve the normal equation to get theta
+                            Matrix theta = SolveNormalEquation(features, values);
+
+                            // Calculate the difference for the incoming points
+                            Matrix target = Matrix.CreateInstance(1, 3);
+                            target[0, 0] = 1f;
+                            target[0, 1] = sAxes[0] * sAxes[0];
+                            target[0, 2] = sAxes[1] * sAxes[1];
+
+                            offsets = target * theta;
+
+
+                            _stringBuilder.AppendLine("Features");
+                            _stringBuilder.AppendLine(features.ToString());
+                            _stringBuilder.AppendLine("Values");
+                            _stringBuilder.AppendLine(values.ToString());
+                            _stringBuilder.AppendLine("Theta");
+                            _stringBuilder.AppendLine(theta.ToString());
+                            _stringBuilder.AppendLine("Target");
+                            _stringBuilder.AppendLine(target.ToString());
+                            _stringBuilder.AppendLine("Offsets");
+                            _stringBuilder.AppendLine(offsets.ToString());
+                            RaiseNotification(NotificationType.Data, _stringBuilder.ToString());
+                            _stringBuilder.Clear();
+
+                            // Cache the offsets and the checksum
+                            _lastOffsets = offsets;
+                            _currentChecksum = checksum;
                         }
-                        _stringBuilder.AppendLine(".");
-
-
-
-                        // Solve the normal equation to get theta
-                        Matrix theta = SolveNormalEquation(features, values);
-
-                        // Calculate the difference for the incoming points
-                        Matrix target = Matrix.CreateInstance(1, 3);
-                        target[0, 0] = 1f;
-                        target[0, 1] = sAxes[0] * sAxes[0];
-                        target[0, 2] = sAxes[1] * sAxes[1];
-
-                        offsets = target * theta;
-
-
-                        _stringBuilder.AppendLine("Features");
-                        _stringBuilder.AppendLine(features.ToString());
-                        _stringBuilder.AppendLine("Values");
-                        _stringBuilder.AppendLine(values.ToString());
-                        _stringBuilder.AppendLine("Theta");
-                        _stringBuilder.AppendLine(theta.ToString());
-                        _stringBuilder.AppendLine("Target");
-                        _stringBuilder.AppendLine(target.ToString());
-                        _stringBuilder.AppendLine("Offsets");
-                        _stringBuilder.AppendLine(offsets.ToString());
-                        RaiseNotification(NotificationType.Data, _stringBuilder.ToString());
-                        _stringBuilder.Clear();
+                        else if (rows > 0)
+                        {
+                            checksum = GetChecksum(AlignmentPoints[0].Id);
+                            if (checksum == _currentChecksum)
+                            {
+                                // Checksum hasn't changed so use the last offsets
+                                offsets = _lastOffsets;
+                            }
+                            else
+                            {
+                                // Use the nearest point of the two.
+                                offsets[0, 0] = alignmentPoints[0].MountAxes[0] - alignmentPoints[0].ObservedAxes[0];
+                                offsets[0, 1] = alignmentPoints[0].MountAxes[1] - alignmentPoints[0].ObservedAxes[1];
+                                alignmentPoints[0].Selected = true;
+                                _selectedPoints.Add(alignmentPoints[0]);
+                                // Cache the offsets and checksum
+                                _lastOffsets = offsets;
+                                _currentChecksum = checksum;
+                                RaiseNotification(NotificationType.Data,
+                                    $"Using nearest point of two {alignmentPoints[0].Id:D3}, Mount axes: {alignmentPoints[0].MountAxes.RaAxis}/{alignmentPoints[0].MountAxes.RaAxis}, Observed axes: {alignmentPoints[0].ObservedAxes.RaAxis}/{alignmentPoints[0].ObservedAxes.RaAxis}");
+                            }
+                        }
                     }
-                    else if (rows > 0)
-                    {
-                        // Use the nearest point of the two.
-                        offsets[0, 0] = alignmentPoints[0].MountAxes[0] - alignmentPoints[0].ObservedAxes[0];
-                        offsets[0, 1] = alignmentPoints[0].MountAxes[1] - alignmentPoints[0].ObservedAxes[1];
-                        alignmentPoints[0].Selected = true;
-                        _selectedPoints.Add(alignmentPoints[0]);
-                        RaiseNotification(NotificationType.Data, $"Using nearest point of two {alignmentPoints[0].Id:D3}, Mount axes: {alignmentPoints[0].MountAxes.RaAxis}/{alignmentPoints[0].MountAxes.RaAxis}, Observed axes: {alignmentPoints[0].ObservedAxes.RaAxis}/{alignmentPoints[0].ObservedAxes.RaAxis}");
 
-                    }
                     // Otherwise default to using zero offset
                 }
                 RaiseNotification(NotificationType.Data, $"Correction -> Mount = {offsets[0, 0]}/{offsets[0, 1]}");
@@ -263,18 +315,20 @@ namespace NStarAlignment.Model
             _selectedPoints.Clear();
         }
 
-        private IEnumerable<AlignmentPoint> GetNearestMountPoints(AxisPosition axisPosition, PierSide pierSide, int numberOfPoints)
+        private AlignmentPoint[] GetNearestMountPoints(AxisPosition axisPosition, PierSide pierSide, int numberOfPoints)
         {
             return AlignmentPoints
                 .Where(p => p.PierSide == pierSide && p.MountAxes.IncludedAngleTo(axisPosition) <= NearbyLimit)
-                .OrderBy(d => d.MountAxes.IncludedAngleTo(axisPosition)).Take(numberOfPoints);
+                .OrderBy(d => d.MountAxes.IncludedAngleTo(axisPosition)).Take(numberOfPoints).ToArray();
         }
 
-        private IEnumerable<AlignmentPoint> GetNearestObservedPoints(AxisPosition axisPosition, PierSide pierSide, int numberOfPoints)
+        private AlignmentPoint[] GetNearestObservedPoints(AxisPosition axisPosition, PierSide pierSide, int numberOfPoints, out int checkSum)
         {
-            return AlignmentPoints
+            AlignmentPoint[] points = AlignmentPoints
                 .Where(p => p.PierSide == pierSide && p.ObservedAxes.IncludedAngleTo(axisPosition) <= NearbyLimit)
-                .OrderBy(d => d.ObservedAxes.IncludedAngleTo(axisPosition)).Take(numberOfPoints);
+                .OrderBy(d => d.ObservedAxes.IncludedAngleTo(axisPosition)).Take(numberOfPoints).ToArray();
+            checkSum = GetChecksum(points.Select(p => p.Id).ToArray());
+            return points;
         }
 
         public static Matrix SolveNormalEquation(Matrix inputFeatures, Matrix outputValue)
@@ -288,6 +342,31 @@ namespace NStarAlignment.Model
             Matrix result = xxi * xy;
             return result;
         }
+
+        #region Adler checksum
+        private const int Mod = 65521;
+        private static int GetChecksum(int[] array)
+        {
+            int i;
+            var a = 1;
+            var b = 0;
+            var size = array.Length;
+            for (i = 0; i < size; i++)
+            {
+                a = (a + array[i]) % Mod;
+                b = (b + a) % Mod;
+            }
+            return (b << 16) | a;
+        }
+
+        private static int GetChecksum(int singleValue)
+        {
+            var a = (1 + singleValue) % Mod;
+            var b = a % Mod;
+            return (b << 16) | a;
+        }
+        #endregion
+
         #endregion
 
     }


### PR DESCRIPTION
Hi Rob, hopefully this pull request will be a little cleaner that the last one. 

I deleted my master branch and created a new one from yours this morning before starting work on this. The updates included address your feedback re CPU usage and the amount of logging that was going on.

I now cache the calculated offsets along with a checksum based on the IDs of the alignment points used. If, on subsequent calls, the selected points match those used for the cached offsets the cached offsets are used. The longer matrix calculations are only used if the alignment points selected by the algorithm have changed.