### PR TITLE
Range controls and range size for alignment settings.

### DIFF
--- a/GS.Server/Alignment/AlignmentV.xaml
+++ b/GS.Server/Alignment/AlignmentV.xaml
@@ -23,27 +23,69 @@
                        IsLeftDrawerOpen="{Binding ElementName=MenuToggleButton, Path=IsChecked}" 
                        BorderBrush="{StaticResource MaterialDesignDivider}">
             <md:DrawerHost.LeftDrawerContent>
-                <Grid Width="350">
+                <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="40" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" MinHeight="150"/>
+                        <RowDefinition Height="Auto" MinHeight="150"/>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <Label Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="18" Content="{StaticResource aliAlignmentSettings}"/>
-                    <ToggleButton Grid.Row="0"  HorizontalAlignment="Right" Margin="5" ToolTip="{StaticResource aliCloseTooltip}"
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="5"/>
+                        <ColumnDefinition Width="50" />
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="18" Content="{StaticResource aliAlignmentSettings}"/>
+                    <ToggleButton Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" Margin="5" ToolTip="{StaticResource aliCloseTooltip}"
                                   Style="{StaticResource MaterialDesignHamburgerToggleButton}" 
                                   Command="{x:Static md:DrawerHost.CloseDrawerCommand}"
                                   CommandParameter="{x:Static Dock.Left}"
                                   IsChecked="{Binding ElementName=MenuToggleButton, Path=IsChecked, Mode=TwoWay}"/>
-                    <TextBox Grid.Row="1" Margin="20,0,5,20" md:HintAssist.Hint="{StaticResource optProximityLimit}" Width="120" HorizontalAlignment="Left" ToolTip="{StaticResource aliProximityLimitTooltip}" 
-                             Text="{Binding ProximityLimit}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" domain:TextBoxMaskBehaviour.Mask="Decimal" />
-                    <TextBox Grid.Row="2" Margin="20,0,5,20" md:HintAssist.Hint="{StaticResource optNearbyLimit}" Width="120" HorizontalAlignment="Left" ToolTip="{StaticResource aliNearbyLimitTooltip}" 
+                    <TextBox Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left"  VerticalAlignment="Bottom" Margin="20,0,5,20" Width="120" IsReadOnly="True"
+                             md:HintAssist.Hint="{StaticResource optProximityLimit}" 
+                             Text="{Binding ProximityLimitArcSeconds}"
+                             ToolTip="{StaticResource aliProximityLimitTooltip}"
+                             Style="{StaticResource MaterialDesignFloatingHintTextBox}" domain:TextBoxMaskBehaviour.Mask="Decimal" />
+                    <Slider Grid.Row="1" Grid.Column="2" Value="{Binding ProximityLimitArcSeconds}" 
+                            Style="{StaticResource MaterialDesignDiscreteSlider}"
+                            ToolTip="{StaticResource aliProximityLimitTooltip}"
+                            Width="75"
+                            Orientation="Vertical"
+                            Minimum="0" Maximum="7200" 
+                            TickFrequency="200"
+                            TickPlacement="None" />
+                    <TextBox Grid.Row="2" Grid.Column="0"  Margin="20,0,5,20" 
+                             md:HintAssist.Hint="{StaticResource optNearbyLimit}" Width="120" HorizontalAlignment="Left" VerticalAlignment="Bottom" IsReadOnly="True"
+                             ToolTip="{StaticResource aliNearbyLimitTooltip}" 
                              Text="{Binding NearbyLimit}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" domain:TextBoxMaskBehaviour.Mask="Decimal"/>
-                    <TextBox Grid.Row="3" Margin="20,0,5,20" md:HintAssist.Hint="{StaticResource optSampleSize}" Width="120" HorizontalAlignment="Left" ToolTip="{StaticResource aliSampleSizeTooltip}" 
-                             Text="{Binding SampleSize}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" domain:TextBoxMaskBehaviour.Mask="Integer"/>
-                    <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="20,0,5,20">
+
+                    <Slider Grid.Row="2" Grid.Column="2" Value="{Binding NearbyLimit}" 
+                            Style="{StaticResource MaterialDesignDiscreteSlider}"
+                            ToolTip="{StaticResource aliNearbyLimitTooltip}"
+                            Width="75"
+                            Orientation="Vertical"
+                            Minimum="5" Maximum="90" 
+                            TickFrequency="5"
+                            TickPlacement="None" />
+                    <!--<TextBox Grid.Row="3" Margin="20,0,5,20" md:HintAssist.Hint="{StaticResource optSampleSize}" Width="120" HorizontalAlignment="Left" ToolTip="{StaticResource aliSampleSizeTooltip}" 
+                             Text="{Binding SampleSize}" Style="{StaticResource MaterialDesignFloatingHintTextBox}" domain:TextBoxMaskBehaviour.Mask="Integer"/>-->
+                    <ComboBox Grid.Row="3" Grid.ColumnSpan="3" Grid.Column="0" Margin="20,0,5,20" md:HintAssist.Hint="{StaticResource optSampleSize}" Width="120" HorizontalAlignment="Left" ToolTip="{StaticResource aliSampleSizeTooltip}"
+                              ItemsSource="{Binding SampleSizeList}" Style="{StaticResource MaterialDesignFloatingHintComboBox}">
+                        <ComboBox.SelectedItem>
+                            <Binding Path="SampleSize" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
+                                <Binding.ValidationRules>
+                                    <domain:NotEmptyValidationRule ValidatesOnTargetUpdated="True"/>
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </ComboBox.SelectedItem>
+                        <ComboBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel />
+                            </ItemsPanelTemplate>
+                        </ComboBox.ItemsPanel>
+                    </ComboBox>
+                    <StackPanel Grid.Row="4" Grid.ColumnSpan="3" Grid.Column="0" Orientation="Horizontal" Margin="20,0,5,20">
                         <ToggleButton Style="{StaticResource MaterialDesignActionLightToggleButton}" HorizontalAlignment="Center" Width="25" Height="25" ToolTip="{StaticResource aliClearModelOnStartupTooltip}"
                                       IsChecked="{Binding ClearModelOnStartup, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <Label VerticalAlignment="Bottom" HorizontalAlignment="Center" Content="{StaticResource aliClearModelOnStartup}"/>

--- a/GS.Server/Alignment/AlignmentVM.cs
+++ b/GS.Server/Alignment/AlignmentVM.cs
@@ -24,6 +24,7 @@ using GS.Shared.Command;
 using MaterialDesignThemes.Wpf;
 using NStarAlignment.DataTypes;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
@@ -119,12 +120,12 @@ namespace GS.Server.Alignment
             }
         }
 
-        public double ProximityLimit
+        public double ProximityLimitArcSeconds
         {
-            get => AlignmentSettings.ProximityLimit;
+            get => AlignmentSettings.ProximityLimit * 3600;
             set
             {
-                AlignmentSettings.ProximityLimit = value;
+                AlignmentSettings.ProximityLimit = value / 3600;
                 OnPropertyChanged();
             }
 
@@ -140,6 +141,8 @@ namespace GS.Server.Alignment
             }
 
         }
+
+        public IList<int> SampleSizeList { get; } = new List<int>(Enumerable.Range(2, 8));
 
         public int SampleSize
         {

--- a/GS.Shared/LanguageFiles/GSServer_en-US.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_en-US.xaml
@@ -598,8 +598,8 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="aliAlignmentOnTooltip">Switch on star alignment modeling</system:String>
     <system:String x:Key="aliClearModelOnStartup">Clear model on startup</system:String>
     <system:String x:Key="aliAlignmentSettings">Settings</system:String>
-    <system:String x:Key="aliProximityLimitTooltip">How near to each other can sync points be before they replace earlier points (degrees).</system:String>
-    <system:String x:Key="aliSampleSizeTooltip">How many nearby sync points should be used when calculating positions (degrees).</system:String>
+    <system:String x:Key="aliProximityLimitTooltip">How near to each other can sync points be before they replace earlier points (arc seconds).</system:String>
+    <system:String x:Key="aliSampleSizeTooltip">How many nearby sync points should be used when calculating positions.</system:String>
     <system:String x:Key="aliNearbyLimitTooltip">How close should sync points be before they are used in calculations (degrees).</system:String>
     <system:String x:Key="aliClearModelOnStartupTooltip">Tick if you want to create a fresh model every time you reconnect.</system:String>
     <system:String x:Key="aliClearAll">Clear All</system:String>

--- a/GS.Shared/LanguageFiles/GSServer_fr-FR.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_fr-FR.xaml
@@ -599,8 +599,8 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="aliAlignmentOn">Activer la modélisation de l'alignement des étoiles</system:String>
     <system:String x:Key="aliAlignmentOnTooltip">Activer la modélisation de l'alignement des étoiles</system:String>
     <system:String x:Key="aliAlignmentSettings">Paramètres</system:String>
-    <system:String x:Key="aliProximityLimitTooltip">À quelle distance les uns des autres peuvent être synchronisés les points avant qu'ils ne remplacent les points précédents (degrés).</system:String>
-    <system:String x:Key="aliSampleSizeTooltip">Combien de points de synchronisation à proximité doivent être utilisés lors du calcul des positions (degrés).</system:String>
+    <system:String x:Key="aliProximityLimitTooltip">À quelle distance les uns des autres peuvent être synchronisés les points avant qu'ils ne remplacent les points précédents (Secondes d'arc).</system:String>
+    <system:String x:Key="aliSampleSizeTooltip">Combien de points de synchronisation à proximité doivent être utilisés lors du calcul des positions.</system:String>
     <system:String x:Key="aliNearbyLimitTooltip">À quelle distance les points de synchronisation doivent-ils être avant d’être utilisés dans les calculs (degrés).</system:String>
     <system:String x:Key="aliClearModelOnStartup">Modèle clair au démarrage</system:String>
     <system:String x:Key="aliClearModelOnStartupTooltip">Cochez si vous souhaitez créer un nouveau modèle chaque fois que vous vous reconnectez.</system:String>

--- a/GS.Shared/Languages/StringResServer_en-us.xaml
+++ b/GS.Shared/Languages/StringResServer_en-us.xaml
@@ -602,8 +602,8 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="aliAlignmentOnTooltip">Switch on star alignment modeling</system:String>
     <system:String x:Key="aliClearModelOnStartup">Clear model on startup</system:String>
     <system:String x:Key="aliAlignmentSettings">Settings</system:String>
-    <system:String x:Key="aliProximityLimitTooltip">How near to each other can sync points be before they replace earlier points (degrees).</system:String>
-    <system:String x:Key="aliSampleSizeTooltip">How many nearby sync points should be used when calculating positions (degrees).</system:String>
+    <system:String x:Key="aliProximityLimitTooltip">How near to each other can sync points be before they replace earlier points (arc seconds).</system:String>
+    <system:String x:Key="aliSampleSizeTooltip">How many nearby sync points should be used when calculating positions.</system:String>
     <system:String x:Key="aliNearbyLimitTooltip">How close should sync points be before they are used in calculations (degrees).</system:String>
     <system:String x:Key="aliClearModelOnStartupTooltip">Tick if you want to create a fresh model every time you reconnect.</system:String>
     <system:String x:Key="aliClearAll">Clear All</system:String>

--- a/NStarAlignment/Model/AlignmentModel.cs
+++ b/NStarAlignment/Model/AlignmentModel.cs
@@ -84,9 +84,9 @@ namespace NStarAlignment.Model
 
         /// <summary>
         /// How close existing alignment points have to be to the new alignment point
-        /// before they are removed and replaced with the new one (Degrees)
+        /// before they are removed and replaced with the new one (degrees)
         /// </summary>
-        public double ProximityLimit { get; set; } = 2.0;
+        public double ProximityLimit { get; set; } = 0.5;
 
         /// <summary>
         /// How many sample points should be used.
@@ -96,7 +96,7 @@ namespace NStarAlignment.Model
         /// <summary>
         /// How close do points have to be to be considered for inclusion in the sample (Degrees)
         /// </summary>
-        public double NearbyLimit { get; set; } = 90.0;
+        public double NearbyLimit { get; set; } = 45.0;
 
 
         public double SiteLongitude { get; set; }


### PR DESCRIPTION
The Alignment Settings UI has been updated to include range controls. The displayed value for the proximity limit has been converted to arc seconds and the range set to 0 -7200 using a slider. The nearby limit uses a range 5 - 90 again using a slider. The number of nearby points is ranged from 2 to 10 using a dropdown list.