### PR TITLE
Fix NPE on Device.Equals

### DIFF
--- a/GS.Shared/Transport/Device.cs
+++ b/GS.Shared/Transport/Device.cs
@@ -57,7 +57,7 @@ namespace GS.Shared.Transport
             }
         }
 
-        public bool Equals(Device other) => Index > 0 ? Index == other?.Index : Endpoint.Equals(other.Endpoint);
+        public bool Equals(Device other) => Index > 0 ? Index == other?.Index : object.Equals(Endpoint, other.Endpoint);
 
         public override string ToString()
         {


### PR DESCRIPTION
Fixes `NullReferenceException` when comparing with a `null` Device