### PR TITLE
Fix Device discovery

### DIFF
--- a/GS.Server/App.config
+++ b/GS.Server/App.config
@@ -284,7 +284,7 @@
             <setting name="Version" serializeAs="String">
                 <value>0</value>
             </setting>
-            <setting name="ComPort" serializeAs="String">
+            <setting name="DeviceIndex" serializeAs="String">
                 <value>1</value>
             </setting>
             <setting name="BaudRate" serializeAs="String">

--- a/GS.Server/Properties/SkyTelescope.Designer.cs
+++ b/GS.Server/Properties/SkyTelescope.Designer.cs
@@ -38,9 +38,9 @@ namespace GS.Server.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
-        public int DeviceIndex {
+        public long DeviceIndex {
             get {
-                return ((int)(this["DeviceIndex"]));
+                return ((long)(this["DeviceIndex"]));
             }
             set {
                 this["DeviceIndex"] = value;

--- a/GS.Server/Properties/SkyTelescope.settings
+++ b/GS.Server/Properties/SkyTelescope.settings
@@ -5,7 +5,7 @@
     <Setting Name="Version" Type="System.String" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="ComPort" Type="System.Int32" Scope="User">
+    <Setting Name="DeviceIndex" Type="System.Int64" Scope="User">
       <Value Profile="(Default)">1</Value>
     </Setting>
     <Setting Name="BaudRate" Type="System.String" Scope="User">

--- a/GS.Server/SkyTelescope/SkyServer.cs
+++ b/GS.Server/SkyTelescope/SkyServer.cs
@@ -39,6 +39,7 @@ using GS.Server.Windows;
 using GS.Server.Alignment;
 using AxisStatus = GS.Simulator.AxisStatus;
 using Range = GS.Principles.Range;
+using GS.Shared.Transport;
 
 namespace GS.Server.SkyTelescope
 {
@@ -4032,8 +4033,9 @@ namespace GS.Server.SkyTelescope
             { Datetime = HiResDateTime.UtcNow, Device = MonitorDevice.Server, Category = MonitorCategory.Mount, Type = MonitorType.Information, Method = MethodBase.GetCurrentMethod()?.Name, Thread = Thread.CurrentThread.ManagedThreadId, Message = $"{SkySettings.Mount}" };
             MonitorLog.LogToMonitor(monitorItem);
 
-            // setup server defaults, connect serial port, start queues
+            // setup server defaults, stop auto-discovery, connect serial port, start queues
             Defaults();
+            SkySystem.DiscoveryService.StopAutoDiscovery();
             switch (SkySettings.Mount)
             {
                 case MountType.Simulator:

--- a/GS.Server/SkyTelescope/SkySettings.cs
+++ b/GS.Server/SkyTelescope/SkySettings.cs
@@ -839,16 +839,10 @@ namespace GS.Server.SkyTelescope
             }
         }
 
-        private static IList<Device> _devices = new List<Device>();
+        public static IList<Device> Devices { get; } = new List<Device>();
 
-        public static IList<Device> Devices
-        {
-            get => _devices;
-            set => _devices = value ?? new List<Device>();
-        }
-
-        private static int _deviceIndex;
-        public static int DeviceIndex
+        private static long _deviceIndex;
+        public static long DeviceIndex
         {
             get => _deviceIndex;
             set
@@ -863,7 +857,7 @@ namespace GS.Server.SkyTelescope
 
         public static bool TryGetDevice(out Device device) => TryGetDevice(DeviceIndex, out device);
 
-        public static bool TryGetDevice(int deviceIndex, out Device device)
+        public static bool TryGetDevice(long deviceIndex, out Device device)
         {
             var devices = Devices;
             device = devices?.Count > 0 ? devices.SingleOrDefault(x => x.Index == deviceIndex) : default;

--- a/GS.Server/SkyTelescope/SkySystem.cs
+++ b/GS.Server/SkyTelescope/SkySystem.cs
@@ -31,10 +31,12 @@ namespace GS.Server.SkyTelescope
         private static long _idCount;
         private static readonly ConcurrentDictionary<long, bool> ConnectStates;
         public static ISerialPort Serial { get; private set; }
+        public static IDiscoveryService DiscoveryService { get; }
 
         static SkySystem()
         {
             ConnectStates = new ConcurrentDictionary<long, bool>();
+            DiscoveryService = new DiscoveryService();
             _idCount = 0;
         }
 

--- a/GS.Server/SkyTelescope/SkyTelescopeV.xaml
+++ b/GS.Server/SkyTelescope/SkyTelescopeV.xaml
@@ -51,7 +51,8 @@
                                     CommandParameter="{x:Static Dock.Left}" IsChecked="{Binding ElementName=MenuToggleButton, Path=IsChecked}"/>
                                 </Grid>
                             <ComboBox Grid.Row="1" Grid.Column="0" md:HintAssist.Hint="{StaticResource skyPorts}" MinWidth="10" Margin="0,0,0,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyPorts}"  
-                                      ItemsSource="{Binding Devices, UpdateSourceTrigger=PropertyChanged}"
+                                      ItemsSource="{Binding Devices, UpdateSourceTrigger=Default}"
+                                      DisplayMemberPath="Name"
                                       SelectedItem="{Binding SelectedDevice, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                       Style="{StaticResource MaterialDesignFloatingHintComboBox}">
                                 <ComboBox.ItemsPanel>

--- a/GS.Server/SkyTelescope/SkyTelescopeV.xaml
+++ b/GS.Server/SkyTelescope/SkyTelescopeV.xaml
@@ -17,6 +17,7 @@
         <domain:ComparisonConverter x:Key="Compare" />
         <domain:InverseBooleanConverter x:Key="InvertBool" />
         <domain:EnumToVisibilityConverter x:Key="EnumToVis" />
+        <domain1:EnumValueToDescriptionConverter x:Key="EnumToDesc" />
     </UserControl.Resources>
     <md:DialogHost IsOpen="{Binding IsDialogOpen}" DialogContent="{Binding DialogContent}" CloseOnClickAway="True"  >
         <Grid MinWidth="800">
@@ -62,11 +63,16 @@
                                 </ComboBox.ItemsPanel>
                             </ComboBox>
                             <ComboBox Grid.Row="1" Grid.Column="1" md:HintAssist.Hint="{StaticResource skyBaud}" MinWidth="10" Margin="10,0,0,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyBaud}"
-                                      ItemsSource="{Binding Source={domain1:EnumBindingSource {x:Type enums:SerialSpeed}}}"
+                                      ItemsSource="{Binding Source={domain1:EnumValueBindingSourceExtension {x:Type enums:SerialSpeed}}}"
                                       Style="{StaticResource MaterialDesignFloatingHintComboBox}">
                                 <ComboBox.Text>
                                     <Binding Path="BaudRate" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged"/>
                                 </ComboBox.Text>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Mode=OneTime, Converter={StaticResource EnumToDesc}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
                                 <ComboBox.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <VirtualizingStackPanel />
@@ -74,8 +80,8 @@
                                 </ComboBox.ItemsPanel>
                             </ComboBox>
                             <ComboBox Grid.Row="1" Grid.Column="3" md:HintAssist.Hint="{StaticResource skyEquatorial}" MinWidth="10" Margin="10,0,0,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyEquatorial}"
-                                      ItemsSource="{Binding Source={domain1:EnumBindingSource {x:Type deviceInterface:EquatorialCoordinateType}}}" 
-                                      Style="{StaticResource MaterialDesignFloatingHintComboBox}"> 
+                                      ItemsSource="{Binding Source={domain1:EnumValueBindingSourceExtension {x:Type deviceInterface:EquatorialCoordinateType}}}" 
+                                      Style="{StaticResource MaterialDesignFloatingHintComboBox}">
                                 <ComboBox.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <VirtualizingStackPanel />
@@ -84,9 +90,14 @@
                                 <ComboBox.Text>
                                         <Binding Path="EquatorialCoordinateType" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged"/>
                                 </ComboBox.Text>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Mode=OneTime, Converter={StaticResource EnumToDesc}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
                             </ComboBox>
                             <ComboBox Grid.Row="1" Grid.Column="4" md:HintAssist.Hint="{StaticResource skyAlignment}" MinWidth="10" Margin="10,0,0,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyAlignment}"
-                                      ItemsSource="{Binding Source={domain1:EnumBindingSource {x:Type deviceInterface:AlignmentModes}}}"
+                                      ItemsSource="{Binding Source={domain1:EnumValueBindingSourceExtension {x:Type deviceInterface:AlignmentModes}}}"
                                       Style="{StaticResource MaterialDesignFloatingHintComboBox}" IsEnabled="False">
                                 <ComboBox.ItemsPanel>
                                     <ItemsPanelTemplate>
@@ -96,6 +107,11 @@
                                 <ComboBox.Text>
                                     <Binding Path="AlignmentMode" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged"/>
                                 </ComboBox.Text>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Mode=OneTime, Converter={StaticResource EnumToDesc}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
                             </ComboBox>
                             <ComboBox Grid.Row="2" Grid.Column="0" md:HintAssist.Hint="{StaticResource skyRaGuiding}" MinWidth="10" Margin="0,0,0,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyRaGuiding}"
                                       ItemsSource="{Binding GuideRateOffsetList}" Style="{StaticResource MaterialDesignFloatingHintComboBox}">
@@ -128,7 +144,7 @@
                                 </ComboBox.ItemsPanel>
                             </ComboBox>
                             <ComboBox Grid.Row="1" Grid.Column="2" md:HintAssist.Hint="{StaticResource skyMount}" MinWidth="10" Margin="10,0,0,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyMount}"
-                                      ItemsSource="{Binding Source={domain1:EnumBindingSource {x:Type skyTelescope:MountType}}}"
+                                      ItemsSource="{Binding Source={domain1:EnumValueBindingSourceExtension {x:Type skyTelescope:MountType}}}"
                                       Style="{StaticResource MaterialDesignFloatingHintComboBox}">
                                 <ComboBox.ItemsPanel>
                                     <ItemsPanelTemplate>
@@ -138,6 +154,11 @@
                                 <ComboBox.Text>
                                     <Binding Path="Mount" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged"/>
                                 </ComboBox.Text>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Mode=OneTime, Converter={StaticResource EnumToDesc}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
                             </ComboBox>
                             <ComboBox Grid.Row="2" Grid.Column="4" md:HintAssist.Hint="{StaticResource skyMaxSlew}" MinWidth="10" Margin="10,0,0,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyMaxSlew}"
                                       ItemsSource="{Binding MaxSlewRates}" Style="{StaticResource MaterialDesignFloatingHintComboBox}">
@@ -200,7 +221,7 @@
                                 </ComboBox.ItemsPanel>
                             </ComboBox>
                             <ComboBox Grid.Row="3" Grid.Column="2" md:HintAssist.Hint="{StaticResource skyTracking}" MinWidth="10" Margin="10,0,5,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyTracking}"
-                                  ItemsSource="{Binding Source={domain1:EnumBindingSource {x:Type deviceInterface:DriveRates}}}" Style="{StaticResource MaterialDesignFloatingHintComboBox}">
+                                  ItemsSource="{Binding Source={domain1:EnumValueBindingSourceExtension {x:Type deviceInterface:DriveRates}}}" Style="{StaticResource MaterialDesignFloatingHintComboBox}">
                                 <ComboBox.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <VirtualizingStackPanel />
@@ -209,6 +230,11 @@
                                 <ComboBox.Text>
                                     <Binding Path="TrackingRate" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged" />
                                 </ComboBox.Text>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Mode=OneTime, Converter={StaticResource EnumToDesc}}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
                             </ComboBox>
                             <ComboBox Grid.Row="3" Grid.Column="3" md:HintAssist.Hint="{StaticResource skyPolarLedLevel}" MinWidth="10" Margin="10,0,0,0" VerticalAlignment="Center"  ToolTip="{StaticResource skyPolarLedLevel}" ItemsSource="{Binding PolarLedLevels}" Style="{StaticResource MaterialDesignFloatingHintComboBox}" IsEnabled="{Binding PolarLedLevelEnabled}">
                                     <ComboBox.SelectedItem>
@@ -692,7 +718,7 @@
                         </Grid>
                     <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="0" HorizontalAlignment="Center">
                         <controls:BottomStatusBar IsEnabled="{Binding ScreenEnabled}"/>
-                        <ComboBox md:HintAssist.Hint="{StaticResource skyMount}" IsEnabled="{Binding ScreenEnabled, Converter={StaticResource InvertBool}}"  Height="38" Margin="5,0,0,0" ToolTip="{StaticResource skyMount}" ItemsSource="{Binding Source={domain1:EnumBindingSource {x:Type skyTelescope:MountType}}}" Style="{StaticResource MaterialDesignFloatingHintComboBox}">
+                        <ComboBox md:HintAssist.Hint="{StaticResource skyMount}" IsEnabled="{Binding ScreenEnabled, Converter={StaticResource InvertBool}}"  Height="38" Margin="5,0,0,0" ToolTip="{StaticResource skyMount}" ItemsSource="{Binding Source={domain1:EnumValueBindingSourceExtension {x:Type skyTelescope:MountType}}}" Style="{StaticResource MaterialDesignFloatingHintComboBox}">
                             <ComboBox.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <VirtualizingStackPanel />
@@ -701,6 +727,11 @@
                             <ComboBox.Text>
                                 <Binding Path="Mount" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged" />
                             </ComboBox.Text>
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Mode=OneTime, Converter={StaticResource EnumToDesc}}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
                         </ComboBox>
                         <Button Margin="10,0,0,0" Height="30" ToolTip="{StaticResource skyConnectDis}" 
                                 Command="{Binding ClickConnectCommand}" Content="{Binding ConnectButtonContent}" Style="{StaticResource MaterialDesignRaisedDarkButton}"/>

--- a/GS.Server/SkyTelescope/SkyTelescopeV.xaml.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeV.xaml.cs
@@ -18,12 +18,12 @@ namespace GS.Server.SkyTelescope
         private void SkyTelescopeV_OnLoaded(object sender, RoutedEventArgs e)
         {
             var ctx = DataContext as SkyTelescopeVM;
-            var udpDiscoverService = ctx?.DiscoveryService;
-            if (udpDiscoverService != null)
+            var discoveryService = ctx?.DiscoveryService;
+            if (discoveryService != null)
             {
-                udpDiscoverService.DiscoveredDeviceEvent += UdpDiscoveryService_DiscoveredDeviceEvent;
-                udpDiscoverService.RemovedDeviceEvent += UdpDiscoveryService_RemovedDeviceEvent;
-                udpDiscoverService.Discover();
+                discoveryService.DiscoveredDeviceEvent += UdpDiscoveryService_DiscoveredDeviceEvent;
+                discoveryService.RemovedDeviceEvent += UdpDiscoveryService_RemovedDeviceEvent;
+                discoveryService.StartAutoDiscovery();
             }
         }
 

--- a/GS.Server/SkyTelescope/SkyTelescopeV.xaml.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeV.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.InteropServices;
+﻿using GS.Shared.Transport;
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
 
@@ -22,49 +25,40 @@ namespace GS.Server.SkyTelescope
             if (discoveryService != null)
             {
                 discoveryService.DiscoveredDeviceEvent += UdpDiscoveryService_DiscoveredDeviceEvent;
-                discoveryService.RemovedDeviceEvent += UdpDiscoveryService_RemovedDeviceEvent;
                 discoveryService.StartAutoDiscovery();
             }
         }
 
-        private void UdpDiscoveryService_DiscoveredDeviceEvent(object sender, Shared.Transport.DiscoveryEventArgs e)
+        private void UdpDiscoveryService_DiscoveredDeviceEvent(object sender, DiscoveryEventArgs e)
         {
             Dispatcher.InvokeAsync(() =>
             {
                 if (DataContext is SkyTelescopeVM ctx)
                 {
                     var hasChanges = false;
-
-                    foreach (var device in e.Devices)
+                    for (var i = 0; i < e.Devices.Count; i++)
                     {
-                        if (!ctx.Devices.Contains(device))
+                        var discoveredDevice = e.Devices[i];
+                        var existingIndex = SkySettings.Devices.IndexOf(discoveredDevice);
+                        if (existingIndex >= 0)
                         {
-                            ctx.Devices.Add(device);
+                            SkySettings.Devices[existingIndex].DiscoverTimeMs = discoveredDevice.DiscoverTimeMs;
+                        }
+                        else
+                        {
+                            SkySettings.Devices.Add(discoveredDevice);
                             hasChanges = true;
                         }
                     }
 
-                    if (hasChanges)
+                    var timeMs = Environment.TickCount;
+                    var discardOlderThanMs = ctx.DiscoveryService.DiscoveryInterval.TotalMilliseconds;
+                    for (var i = SkySettings.Devices.Count - 1; i >= 0; i--)
                     {
-                        ctx.RaisePropertyChanged(nameof(SkyTelescopeVM.Devices));
-                        ctx.RaisePropertyChanged(nameof(SkyTelescopeVM.SelectedDevice));
-                    }
-                }
-            });
-        }
-
-        private void UdpDiscoveryService_RemovedDeviceEvent(object sender, Shared.Transport.DiscoveryEventArgs e)
-        {
-            Dispatcher.InvokeAsync(() =>
-            {
-                if (DataContext is SkyTelescopeVM ctx)
-                {
-                    var hasChanges = false;
-
-                    foreach (var device in e.Devices)
-                    {
-                        if (ctx.Devices.Remove(device))
+                        var existingDevice = SkySettings.Devices[i];
+                        if (!e.Devices.Contains(existingDevice) && timeMs - existingDevice.DiscoverTimeMs > discardOlderThanMs)
                         {
+                            SkySettings.Devices.RemoveAt(i);
                             hasChanges = true;
                         }
                     }

--- a/GS.Server/SkyTelescope/SkyTelescopeV.xaml.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeV.xaml.cs
@@ -52,11 +52,13 @@ namespace GS.Server.SkyTelescope
                     }
 
                     var timeMs = Environment.TickCount;
-                    var discardOlderThanMs = ctx.DiscoveryService.DiscoveryInterval.TotalMilliseconds;
+                    // discard anything not detected in two scans
+                    var discardOlderThanMs = ctx.DiscoveryService.DiscoveryInterval.TotalMilliseconds * 2;
                     for (var i = SkySettings.Devices.Count - 1; i >= 0; i--)
                     {
                         var existingDevice = SkySettings.Devices[i];
-                        if (!e.Devices.Contains(existingDevice) && timeMs - existingDevice.DiscoverTimeMs > discardOlderThanMs)
+                        // Do not remove UDP devices when doing asynchronous discovery
+                        if ((!e.IsSynchronous || existingDevice.Index > 0) && timeMs - existingDevice.DiscoverTimeMs > discardOlderThanMs)
                         {
                             SkySettings.Devices.RemoveAt(i);
                             hasChanges = true;

--- a/GS.Server/SkyTelescope/SkyTelescopeVM.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeVM.cs
@@ -2117,9 +2117,13 @@ namespace GS.Server.SkyTelescope
 
                 _openSetupDialog = value;
 
-                DiscoveryService.Discover();
-                if (!value)
+                if (value)
                 {
+                    DiscoveryService.StartAutoDiscovery();
+                }
+                else
+                {
+                    DiscoveryService.StopAutoDiscovery();
                     ClickCloseSettings();
                 }
 

--- a/GS.Server/SkyTelescope/SkyTelescopeVM.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeVM.cs
@@ -52,6 +52,7 @@ using MouseEventArgs = System.Windows.Input.MouseEventArgs;
 using NativeMethods = GS.Server.Helpers.NativeMethods;
 using Point = System.Windows.Point;
 using GS.Shared.Transport;
+using System.Collections.ObjectModel;
 
 namespace GS.Server.SkyTelescope
 {
@@ -85,10 +86,6 @@ namespace GS.Server.SkyTelescope
                         Message = "Loading SkyTelescopeVM"
                     };
                     MonitorLog.LogToMonitor(monitorItem);
-
-
-                    // discovery service
-                    DiscoveryService = new DiscoveryService();
 
                     _skyTelescopeVM = this;
                     LoadImages();  // load front image
@@ -727,17 +724,17 @@ namespace GS.Server.SkyTelescope
             }
         }
 
-        public IDiscoveryService DiscoveryService { get; }
+        public IDiscoveryService DiscoveryService => SkySystem.DiscoveryService;
 
-        public IList<Device> Devices => SkySettings.Devices;
+        public ObservableCollection<Device> Devices => new ObservableCollection<Device>(SkySettings.Devices);
 
         public Device SelectedDevice
         {
             get => Devices.SingleOrDefault(device => device.Index == SkySettings.DeviceIndex);
             set
             {
-                if (value.Index == SkySettings.DeviceIndex) return;
-                SkySettings.DeviceIndex = value.Index;
+                if (value?.Index == SkySettings.DeviceIndex) return;
+                SkySettings.DeviceIndex = value?.Index ?? 0;
                 OnPropertyChanged();
             }
         }
@@ -2119,7 +2116,11 @@ namespace GS.Server.SkyTelescope
 
                 if (value)
                 {
-                    DiscoveryService.StartAutoDiscovery();
+                    // only start discovery if mount is not connected to not interfere with the WiFi communication
+                    if (!this.IsConnected)
+                    {
+                        DiscoveryService.StartAutoDiscovery();
+                    }
                 }
                 else
                 {
@@ -8523,6 +8524,7 @@ namespace GS.Server.SkyTelescope
             if (disposing)
             {
                 _util?.Dispose();
+                DiscoveryService?.Dispose();
             }
 
             // free native resources if there are any.

--- a/GS.Shared/Domain/EnumBindingSourceExtension.cs
+++ b/GS.Shared/Domain/EnumBindingSourceExtension.cs
@@ -55,7 +55,6 @@ namespace GS.Shared.Domain
             }
 
             var actualEnumType = Nullable.GetUnderlyingType(_enumType) ?? _enumType;
-            //var enumValues = Enum.GetValues(actualEnumType);
             var enumValues = Enum.GetNames(actualEnumType);
 
             if (actualEnumType == _enumType)

--- a/GS.Shared/Domain/EnumUtils.cs
+++ b/GS.Shared/Domain/EnumUtils.cs
@@ -1,0 +1,42 @@
+﻿/* Copyright(C) 2019-2022 Rob Morgan (robert.morgan.e@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace GS.Shared.Domain
+{
+    internal static class EnumUtils
+    {
+        public static bool TryGetField(object value, out FieldInfo field)
+        {
+
+            var type = value.GetType();
+            if (!type.IsEnum)
+            {
+                field = null;
+                return false;
+            }
+            field = type.GetField(value.ToString());
+            return field != null;
+        }
+
+        public static IEnumerable<TAttribute> GetAttributes<TAttribute>(FieldInfo field)
+            where TAttribute : Attribute => field.GetCustomAttributes(typeof(TAttribute), true).Cast<TAttribute>();
+    }
+}

--- a/GS.Shared/Domain/EnumValueToDescriptionConverter.cs
+++ b/GS.Shared/Domain/EnumValueToDescriptionConverter.cs
@@ -1,0 +1,73 @@
+﻿/* Copyright(C) 2019-2022 Rob Morgan (robert.morgan.e@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows.Data;
+
+namespace GS.Shared.Domain
+{
+    public sealed class EnumValueToDescriptionConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+            if (!EnumUtils.TryGetField(value, out var field))
+            {
+                return null;
+            }
+
+            var attr = EnumUtils.GetAttributes<DescriptionAttribute>(field).FirstOrDefault();
+            if (attr != null)
+            {
+                return attr.Description;
+            }
+            else
+            {
+                var name = field.Name;
+                if (char.IsLower(name[0]))
+                {
+                    return CamelCaseConverter.Replace(
+                        LowerCaseAtBeginning.Replace(name, "", 1), 
+                        " $1"
+                    ).Trim();
+                }
+                else
+                {
+                    return name;
+                }
+            }
+        }
+
+        static readonly Regex LowerCaseAtBeginning = new Regex("(^[a-z]+)");
+        static readonly Regex CamelCaseConverter = new Regex("([A-Z0-9]+)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+        #endregion
+    }
+}

--- a/GS.Shared/ThreadContext.cs
+++ b/GS.Shared/ThreadContext.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Threading;
 using System.Windows;
+using System.Windows.Threading;
 
 namespace GS.Shared
 {
@@ -45,13 +46,16 @@ namespace GS.Shared
         /// <param name="action"></param>
         public static void BeginInvokeOnUiThread(Action action)
         {
-            if (Application.Current.Dispatcher != null && Application.Current.Dispatcher.CheckAccess())
+            if (Application.Current?.Dispatcher is Dispatcher dispatcher)
             {
-                action();
-            }
-            else
-            {
-                if (Application.Current.Dispatcher != null) Application.Current.Dispatcher.BeginInvoke(action);
+                if (dispatcher.CheckAccess())
+                {
+                    action();
+                }
+                else
+                {
+                    dispatcher.BeginInvoke(action);
+                }
             }
         }
     }

--- a/GS.Shared/Transport/Device.cs
+++ b/GS.Shared/Transport/Device.cs
@@ -12,7 +12,7 @@ namespace GS.Shared.Transport
     {
         internal const int DefaultPort = 11880;
 
-        public Device(int index, IPEndPoint endpoint = null)
+        public Device(long index, IPEndPoint endpoint = null)
         {
             if (endpoint == null && index <= 0)
             {
@@ -21,18 +21,21 @@ namespace GS.Shared.Transport
 
             Index = index;
             Endpoint = endpoint;
+            DiscoverTimeMs = Environment.TickCount;
         }
 
         /// <summary>
         /// Unique index (-1 or lower) used in device discovery (see <see cref="DiscoveryService.Discover"/>).
         /// Will be the COM port number (1 or greater) if this is a serial device.
         /// </summary>
-        public int Index { get; }
+        public long Index { get; }
 
         /// <summary>
         /// IP Address and port if device is a UDP device, <see langword="null"/> otherwise.
         /// </summary>
         public IPEndPoint Endpoint { get; }
+
+        public long DiscoverTimeMs { get; set; }
 
         public override bool Equals(object obj)
         {
@@ -40,24 +43,11 @@ namespace GS.Shared.Transport
             return Equals(other);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hash = 1009;
-                if (Index > 0)
-                {
-                    hash = (hash * 9176) + Index.GetHashCode();
-                }
-                else if (Endpoint != null)
-                {
-                    hash = (hash * 9176) + Endpoint.GetHashCode();
-                }
-                return hash;
-            }
-        }
+        public override int GetHashCode() => Index.GetHashCode();
 
-        public bool Equals(Device other) => Index > 0 ? Index == other?.Index : object.Equals(Endpoint, other?.Endpoint);
+        public bool Equals(Device other) => Index == other?.Index;
+
+        public string Name => ToString();
 
         public override string ToString()
         {

--- a/GS.Shared/Transport/DiscoveryEventArgs.cs
+++ b/GS.Shared/Transport/DiscoveryEventArgs.cs
@@ -5,10 +5,16 @@ namespace GS.Shared.Transport
 {
     public class DiscoveryEventArgs : EventArgs
     {
-        public DiscoveryEventArgs(IReadOnlyList<Device> devices)
+        public DiscoveryEventArgs(IReadOnlyList<Device> devices, bool isSynchronous = false)
         {
             Devices = devices;
+            IsSynchronous = isSynchronous;
         }
+
+        /// <summary>
+        /// If true then only synchronous discovery was done (serial ports).
+        /// </summary>
+        public bool IsSynchronous { get; }
 
         public IReadOnlyList<Device> Devices { get; }
     }

--- a/GS.Shared/Transport/DiscoveryService.cs
+++ b/GS.Shared/Transport/DiscoveryService.cs
@@ -19,61 +19,45 @@ namespace GS.Shared.Transport
     /// <list type="bullet">
     ///   <item>Discovers all COM serial ports.</item>
     ///   <item>Sends <c>:e1\r</c> to all WiFi broadcast addresses (no NAT traversal).</item>
-    ///   <item>Cleans up non-active and previously discovered devices.</item>
     /// </list>
     /// </summary>
     public class DiscoveryService : IDiscoveryService
     {
+        const int DiscoveryIntervalMs = 2000;
+
         private readonly byte[] DiscoverMsg = Encode(":e1\r");
 
         static byte[] Encode(string msg) => Encoding.ASCII.GetBytes(msg);
         static string Decode(byte[] msg) => msg != null ? Encoding.ASCII.GetString(msg).Replace("\0", "").Trim() : "";
 
         private readonly ConcurrentDictionary<IPAddress, Lazy<UdpClient>> _udpClients;
-        private readonly ConcurrentDictionary<IPEndPoint, int> _dirtyUdpDevices;
-        private readonly ConcurrentDictionary<IPEndPoint, int> _activeUdpDevices;
-        private readonly ConcurrentDictionary<int, Device> _allDevices;
         private readonly DispatcherTimer _timer;
         private readonly int _remotePort;
+        private readonly TimeSpan _broadcastTimeout;
 
-        private volatile int _deviceIndex = 0;
+        private CancellationTokenSource _cts;
         private bool disposedValue;
 
-        public DiscoveryService(int remotePort = Device.DefaultPort)
+        public DiscoveryService(int remotePort = Device.DefaultPort, int discoveryIntervalMs = DiscoveryIntervalMs)
         {
             _udpClients = new ConcurrentDictionary<IPAddress, Lazy<UdpClient>>();
-            _dirtyUdpDevices = new ConcurrentDictionary<IPEndPoint, int>();
-            _activeUdpDevices = new ConcurrentDictionary<IPEndPoint, int>();
-            _allDevices = new ConcurrentDictionary<int, Device>();
             _remotePort = remotePort;
+            DiscoveryInterval = TimeSpan.FromMilliseconds(discoveryIntervalMs);
+            _broadcastTimeout =  TimeSpan.FromMilliseconds(Math.Max(discoveryIntervalMs - 200, 200));
             _timer = new DispatcherTimer
             {
-                Interval = TimeSpan.FromSeconds(2)
+                Interval = DiscoveryInterval
             };
-            _timer.Tick += _timer_Tick;
+            _timer.Tick += TimerTick;
         }
 
-        private void _timer_Tick(object sender, EventArgs e) => Discover();
-
-        public IEnumerable<Device> AllDevices => _allDevices.Values;
-
-        public IEnumerable<Device> ActiveDevices
-        {
-            get
-            {
-                foreach (var activeDeviceId in _activeUdpDevices.Values)
-                {
-                    if (_allDevices.TryGetValue(activeDeviceId, out var device))
-                    {
-                        yield return device;
-                    }
-                }
-            }
-        }
+        private void TimerTick(object sender, EventArgs e) => Discover();
 
         public event EventHandler<DiscoveryEventArgs> DiscoveredDeviceEvent;
 
         public event EventHandler<DiscoveryEventArgs> RemovedDeviceEvent;
+
+        public TimeSpan DiscoveryInterval { get; }
 
         /// <inheritdoc/>
         public void StartAutoDiscovery()
@@ -87,16 +71,18 @@ namespace GS.Shared.Transport
         }
 
         /// <inheritdoc/>
-        public void StopAutoDiscovery() => _timer.Stop();
+        public void StopAutoDiscovery()
+        {
+            _cts?.Cancel();
+            _timer.Stop();
+        }
 
         /// <summary>
         /// Step by step discovery process:
         /// <list type="number">
         ///   <item>Initializes UDP clients for broadcast, one per network interface</item>
-        ///   <item>Removes all UDP devices that where discovered previously but did not respond on last invocation of this method</item>
-        ///   <item>Marks all currently active UDP devices as dirty</item>
         ///   <item>Discovers all COM serial ports (synchronously)</item>
-        ///   <item>Broadcasts and listens for responses</item>
+        ///   <item>Broadcasts to all active network interfaces and listens for responses</item>
         /// </list>
         /// </summary>
         void Discover()
@@ -114,8 +100,6 @@ namespace GS.Shared.Transport
             MonitorLog.LogToMonitor(monitorItem);
 
             InitializeUdpClients();
-            CleanupDirtyUdpDevices();
-            MarkPreviouslyActiveDevicesAsDirty();
             DiscoverSerialDevices();
             BroadcastDiscoverMessage();
         }
@@ -123,7 +107,7 @@ namespace GS.Shared.Transport
         void DiscoverSerialDevices()
         {
             var allPorts = SerialPort.GetPortNames();
-            var portNumbers = new HashSet<int>();
+            var portNumbers = new SortedSet<long>();
             foreach (var port in allPorts)
             {
                 if (string.IsNullOrEmpty(port)) continue;
@@ -134,37 +118,21 @@ namespace GS.Shared.Transport
                 }
             }
 
-            var added = new List<Device>();
-            foreach (var portNumber in portNumbers.OrderBy(x => x))
-            {
-                var device = new Device(portNumber);
-                if (_allDevices.TryAdd(portNumber, device))
-                {
-                    added.Add(device);
-                }
-            }
+            var serialDevices = portNumbers.Select(portNumber => new Device(portNumber)).ToList();
 
-            DiscoveredDeviceEvent?.Invoke(this, new DiscoveryEventArgs(added));
-
-            var removed = new List<Device>();
-            foreach (var deviceIndex in _allDevices.Keys)
-            {
-                if (deviceIndex > 0 && !portNumbers.Contains(deviceIndex) && _allDevices.TryRemove(deviceIndex, out var device))
-                {
-                    removed.Add(device);
-                }
-            }
-
-            RemovedDeviceEvent?.Invoke(this, new DiscoveryEventArgs(removed));
+            DiscoveredDeviceEvent?.Invoke(this, new DiscoveryEventArgs(serialDevices));
         }
 
         void BroadcastDiscoverMessage()
         {
+            var oldCts = Interlocked.Exchange(ref _cts, new CancellationTokenSource(_broadcastTimeout));
+            oldCts?.Cancel();
+
             var broadCastIP = new IPEndPoint(IPAddress.Broadcast, _remotePort);
 
             Parallel.ForEach(
                 _udpClients,
-                kv => kv.Value.Value.BeginSend(DiscoverMsg, DiscoverMsg.Length, broadCastIP, EndSendCb, kv.Key)
+                kv => kv.Value.Value.BeginSend(DiscoverMsg, DiscoverMsg.Length, broadCastIP, EndSendCb, new DiscoveryState(kv.Key, _cts))
             );
         }
 
@@ -220,43 +188,11 @@ namespace GS.Shared.Transport
             }
         }
 
-        /// <summary>
-        /// Removes all devices that are currently dirty (as they have not been fully discovered last run).
-        /// </summary>
-        void CleanupDirtyUdpDevices()
-        {
-            var removed = new List<Device>();
-            foreach (var ep in _dirtyUdpDevices.Keys)
-            {
-                if (_dirtyUdpDevices.TryRemove(ep, out var deviceIndex) && _allDevices.TryRemove(deviceIndex, out var device))
-                {
-                    removed.Add(device);
-                }
-            }
-
-            RemovedDeviceEvent?.Invoke(this, new DiscoveryEventArgs(removed));
-        }
-
-        /// <summary>
-        /// Move currently active devices to the dirty list, and only if they are rediscovered move them back.
-        /// The remaining dirty devices will be cleaned up on <see cref="Dispose"/> or on <see cref="Discover"/>,
-        /// whichever comes first.
-        /// </summary>
-        void MarkPreviouslyActiveDevicesAsDirty()
-        {
-            foreach (var ep in _activeUdpDevices.Keys)
-            {
-                if (_activeUdpDevices.TryRemove(ep, out var device))
-                {
-                    _dirtyUdpDevices.AddOrUpdate(ep, device, (_, old) => device);
-                }
-            }
-        }
-
         void EndSendCb(IAsyncResult sendRes)
         {
-            var sender = sendRes.AsyncState as IPAddress;
-            if (sendRes.IsCompleted && sender != null && _udpClients.TryGetValue(sender, out var updClient))
+            var state = sendRes.AsyncState as DiscoveryState;
+            var sender = state?.InterfaceAddress;
+            if (sendRes.IsCompleted && sender != null && !state.Cts.IsCancellationRequested && _udpClients.TryGetValue(sender, out var updClient))
             {
                 _ = updClient.Value.EndSend(sendRes);
                 updClient.Value.BeginReceive(BeginReceiveEP1Cb, sender);
@@ -279,23 +215,9 @@ namespace GS.Shared.Transport
 
         void OnUdpDeviceDiscovery(IPEndPoint remoteEP)
         {
-            int deviceId;
-            if (_dirtyUdpDevices.TryRemove(remoteEP, out var dirtyDeviceId))
-            {
-                deviceId = _activeUdpDevices.GetOrAdd(remoteEP, dirtyDeviceId);
-            }
-            else if (_activeUdpDevices.TryGetValue(remoteEP, out var activeDeviceId))
-            {
-                deviceId = activeDeviceId;
-            }
-            else
-            {
-                deviceId = _activeUdpDevices.GetOrAdd(remoteEP, _ => Interlocked.Decrement(ref _deviceIndex));
-            }
+            var deviceIndex = GetDeviceIndex(remoteEP);
 
-            var discoveredDevice = _allDevices.GetOrAdd(deviceId, new Device(deviceId, remoteEP));
-
-            DiscoveredDeviceEvent?.Invoke(this, new DiscoveryEventArgs(new[] { discoveredDevice }));
+            DiscoveredDeviceEvent?.Invoke(this, new DiscoveryEventArgs(new[] { new Device(deviceIndex, remoteEP) }));
         }
 
         static bool IsSuccessfulResponse(string response) => response?.Length > 2 && response[0] == '=';
@@ -315,9 +237,7 @@ namespace GS.Shared.Transport
                     }
                 }
 
-                _dirtyUdpDevices.Clear();
-                _activeUdpDevices.Clear();
-                _allDevices.Clear();
+                _cts?.Cancel();
                 _timer.Stop();
 
                 disposedValue =true;
@@ -330,6 +250,37 @@ namespace GS.Shared.Transport
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
+
+        static long GetDeviceIndex(IPEndPoint endpoint)
+        {
+            var id = 0xFF & (long)endpoint.AddressFamily;
+            id <<= 32 + 16;
+            id |= (long)(0xff & endpoint.Port);
+            id <<= 32;
+            if (endpoint.AddressFamily == AddressFamily.InterNetwork)
+            {
+                id |= (long)BitConverter.ToInt32(endpoint.Address.GetAddressBytes(), 0);
+            }
+            else
+            {
+                throw new NotSupportedException($"Address familiy {endpoint.AddressFamily} is not supported");
+            }
+
+            return -Math.Abs(id);
+        }
+    }
+
+    class DiscoveryState
+    {
+        public DiscoveryState(IPAddress interfaceAddress, CancellationTokenSource cts)
+        {
+            InterfaceAddress = interfaceAddress;
+            Cts = cts;
+        }
+
+        public IPAddress InterfaceAddress { get; }
+
+        public CancellationTokenSource Cts { get; }
     }
 }
 

--- a/GS.Shared/Transport/IDiscoveryService.cs
+++ b/GS.Shared/Transport/IDiscoveryService.cs
@@ -9,9 +9,14 @@ namespace GS.Shared.Transport
         IEnumerable<Device> ActiveDevices { get; }
 
         /// <summary>
-        /// Asynchronously sends UDP broadcast messages to discover all reachable devices.
+        /// Start periodic discovery if not already running.
         /// </summary>
-        void Discover();
+        void StartAutoDiscovery();
+
+        /// <summary>
+        /// Stops automatically discoverying devices.
+        /// </summary>
+        void StopAutoDiscovery();
 
         event EventHandler<DiscoveryEventArgs> DiscoveredDeviceEvent;
 

--- a/GS.Shared/Transport/IDiscoveryService.cs
+++ b/GS.Shared/Transport/IDiscoveryService.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-
 namespace GS.Shared.Transport
 {
     public interface IDiscoveryService : IDisposable
     {
-        IEnumerable<Device> AllDevices { get; }
-        IEnumerable<Device> ActiveDevices { get; }
+        TimeSpan DiscoveryInterval { get; }
 
         /// <summary>
         /// Start periodic discovery if not already running.
@@ -19,8 +16,6 @@ namespace GS.Shared.Transport
         void StopAutoDiscovery();
 
         event EventHandler<DiscoveryEventArgs> DiscoveredDeviceEvent;
-
-        event EventHandler<DiscoveryEventArgs> RemovedDeviceEvent;
     }
 }
 

--- a/GS.SkyWatcher/Commands.cs
+++ b/GS.SkyWatcher/Commands.cs
@@ -448,6 +448,7 @@ namespace GS.SkyWatcher
             MonitorLog.LogToMonitor(monitorItem);
         }
 
+        static readonly Version AZGTiAdvancedSupportedVersion = new Version(3, 40);
         /// <summary>
         /// e or X0005 Gets version of the axis
         /// </summary>
@@ -499,20 +500,20 @@ namespace GS.SkyWatcher
                 _axisVersion[1] = intVersion;
                 _axisModel[1] = MountModel;
             }
-            
-            const int a = 0x032200; //205312
 
-            if (intVersion == 0x0325A5) // AZ GTI in EQ mode
+            var version = new Version(first, second);
+            // Exclude AZ GTI in EQ mode prior version 3.40
+            if (MountModel == 165 && version < AZGTiAdvancedSupportedVersion)
             {
                 SupportAdvancedCommandSet = false;
             }
             // SW recommends no support for single axis trackers 0x07, 0x08, 0x0A, and 0x0F
-            //"Star Adventurer Mount" advanced firmware 3.130.07 exclude
+            // "Star Adventurer Mount" advanced firmware 3.130.07 exclude
             else if (intVersion == 0x038207)
             {
                 SupportAdvancedCommandSet = false;
             }
-            else if (intVersion > a)
+            else if (intVersion > 0x032200)  //205312
             {
                 SupportAdvancedCommandSet = true;
             }

--- a/GS.SkyWatcher/SkyQueue.cs
+++ b/GS.SkyWatcher/SkyQueue.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.IO.Ports;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;


### PR DESCRIPTION
- Use a constant device index so that wifi devices can be selected after a restart (given IP address stays the same).
- Support auto-discovery using a timer
- Simplify the implementation
- Add more logging
- Properly detect AZ GTi firmware versionand Advanced Set support
- Make the ASCOM enums like drive rate, EQ system slightly more readable