### PR TITLE
A warning threshold setting has been added to the alignment settings.…

### DIFF
--- a/GS.Server/Alignment/AlignmentModel.cs
+++ b/GS.Server/Alignment/AlignmentModel.cs
@@ -18,7 +18,8 @@ namespace GS.Server.Alignment
         Information,
         Data,
         Warning,
-        Error
+        Error,
+        Debug
     }
 
     [TypeConverter(typeof(EnumTypeConverter))]
@@ -174,6 +175,7 @@ namespace GS.Server.Alignment
                 _alignmentBehaviour = value;
             }
         }
+
         private ThreePointAlgorithmEnum _threePointAlgorithm = ThreePointAlgorithmEnum.BestCentre;
         public ThreePointAlgorithmEnum ThreePointAlgorithm
         {
@@ -184,6 +186,18 @@ namespace GS.Server.Alignment
                 _threePointAlgorithm = value;
             }
         }
+
+        private int _alignmentWarningThreshold = 2;
+        public int AlignmentWarningThreshold
+        {
+            get => _alignmentWarningThreshold;
+            set
+            {
+                if (_alignmentWarningThreshold == value) return;
+                _alignmentWarningThreshold = value;
+            }
+        }
+
 
         public AxisPosition Home { get; private set; }
 
@@ -222,8 +236,8 @@ namespace GS.Server.Alignment
             {
                 if (AlignmentPoints.Any())
                 {
-                    double maxRa = Math.Abs(AlignmentPoints.Max(p => Math.Abs(p.Synced.RA) - Math.Abs(p.Unsynced.RA)));
-                    double maxDec = Math.Abs(AlignmentPoints.Max(p => Math.Abs(p.Synced.Dec) - Math.Abs(p.Unsynced.Dec)));
+                    double maxRa = Math.Abs(AlignmentPoints.Max(p => Math.Abs(p.Synced.RA - p.Unsynced.RA)));
+                    double maxDec = Math.Abs(AlignmentPoints.Max(p => Math.Abs(p.Synced.Dec - p.Unsynced.Dec)));
                     return new double[] { maxRa, maxDec };
                 }
                 else
@@ -284,6 +298,7 @@ namespace GS.Server.Alignment
             AlignmentBehaviour = AlignmentSettings.AlignmentBehaviour;
             ActivePoints = AlignmentSettings.ActivePoints;
             ThreePointAlgorithm = AlignmentSettings.ThreePointAlgorithm;
+            AlignmentWarningThreshold = AlignmentSettings.AlignmentWarningThreshold;
         }
         #endregion
 

--- a/GS.Server/Alignment/AlignmentModel_EqModVector.cs
+++ b/GS.Server/Alignment/AlignmentModel_EqModVector.cs
@@ -116,7 +116,7 @@ namespace GS.Server.Alignment
 
         private Matrix GETLMN(Coord p1, Coord p2, Coord p3)
         {
-
+            RaiseNotification(NotificationType.Debug, "GETLMN", $"Coordinates\np1:({p1.x},{p1.y},{p1.z})\np2:({p2.x},{p2.y},{p2.z})\np3:({p3.x},{p3.y},{p3.z})");
             Matrix temp = Matrix.CreateInstance();
             Matrix UnitVect = Matrix.CreateInstance();
 
@@ -150,6 +150,7 @@ namespace GS.Server.Alignment
             temp.Element[2, 2] = UnitVect.Element[1, 2] * UnitVect.Element[0, 2];
 
 
+            RaiseNotification(NotificationType.Debug, "GETLMN", $"Matrix\n|{temp.Element[0,0]},{temp.Element[0, 1]},{temp.Element[0, 2]}|\n|{temp.Element[1, 0]},{temp.Element[1, 1]},{temp.Element[1, 2]}|\n|{temp.Element[2, 0]},{temp.Element[2, 1]},{temp.Element[2, 2]}|");
 
 
             return temp;

--- a/GS.Server/Alignment/AlignmentSettings.cs
+++ b/GS.Server/Alignment/AlignmentSettings.cs
@@ -54,7 +54,7 @@ namespace GS.Server.Alignment
         {
             get => _isAlertOn;
             set
-            {
+            {   
                 if (_isAlertOn == value) return;
                 _isAlertOn = value;
                 if (_isAlertOn) 
@@ -144,6 +144,21 @@ namespace GS.Server.Alignment
 
         }
 
+        private static int _alignmentWarningThreshold;
+        public static int AlignmentWarningThreshold
+        {
+            get => _alignmentWarningThreshold;
+            set
+            {
+                if (_alignmentWarningThreshold == value) return;
+                _alignmentWarningThreshold = value;
+                Properties.Alignment.Default.AlignmentWarningThreshold = (int)value;
+                LogSetting(MethodBase.GetCurrentMethod()?.Name, $"{value}");
+                OnStaticPropertyChanged();
+            }
+
+        }
+
         private static bool _clearModelOnStartup;
         public static bool ClearModelOnStartup
         {
@@ -176,6 +191,7 @@ namespace GS.Server.Alignment
             AlignmentBehaviour = (AlignmentBehaviourEnum)Properties.Alignment.Default.AlignmentBehaviour;
             ActivePoints = (ActivePointsEnum)Properties.Alignment.Default.ActivePoints;
             ThreePointAlgorithm = (ThreePointAlgorithmEnum)Properties.Alignment.Default.ThreePointAlgorithm;
+            AlignmentWarningThreshold = Properties.Alignment.Default.AlignmentWarningThreshold;
         }
 
         /// <summary>

--- a/GS.Server/Alignment/AlignmentV.xaml
+++ b/GS.Server/Alignment/AlignmentV.xaml
@@ -16,67 +16,69 @@
             Converter={StaticResource ResourceKey=OrdinalConverter}}" HorizontalAlignment="Right" />
         </DataTemplate>
     </UserControl.Resources>-->
-    <Grid MinWidth="600">
-        <md:DialogHost CloseOnClickAway="True"
-                      IsOpen="{Binding IsDialogOpen}" DialogContent="{Binding DialogContent}"/>
+    <md:DialogHost CloseOnClickAway="True"
+                      IsOpen="{Binding IsDialogOpen}" DialogContent="{Binding DialogContent}">
+        <Grid MinWidth="800">
 
-        <md:DrawerHost HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0" 
+            <md:DrawerHost HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderThickness="0" 
                        IsLeftDrawerOpen="{Binding ElementName=MenuToggleButton, Path=IsChecked}" 
                        BorderBrush="{StaticResource MaterialDesignDivider}">
-            <md:DrawerHost.LeftDrawerContent>
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition Height="Auto" MinHeight="150"/>
-                        <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="5"/>
-                        <ColumnDefinition Width="150" />
-                    </Grid.ColumnDefinitions>
-                    <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="18" Content="{StaticResource aliAlignmentSettings}"/>
-                    <ToggleButton Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" Margin="5" ToolTip="{StaticResource aliCloseTooltip}"
+                <md:DrawerHost.LeftDrawerContent>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition Height="Auto" MinHeight="150"/>
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                                <RowDefinition />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="5"/>
+                                <ColumnDefinition Width="150" />
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Row="0" Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="18" Content="{StaticResource aliAlignmentSettings}"/>
+                            <ToggleButton Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" Margin="5" ToolTip="{StaticResource aliCloseTooltip}"
                                   Style="{StaticResource MaterialDesignHamburgerToggleButton}" 
                                   Command="{x:Static md:DrawerHost.CloseDrawerCommand}"
                                   CommandParameter="{x:Static Dock.Left}"
                                   IsChecked="{Binding ElementName=MenuToggleButton, Path=IsChecked, Mode=TwoWay}"/>
 
-                    <ComboBox Grid.Row="1" md:HintAssist.Hint="{StaticResource optAlignmentMode}" 
+                            <ComboBox Grid.Row="1" md:HintAssist.Hint="{StaticResource optAlignmentMode}" 
                               MinWidth="10" Margin="20,0,5,20" Width="200" 
                               HorizontalAlignment="Left" VerticalAlignment="Top" 
                               ToolTip="{StaticResource aliAlignmentModeTooltip}" 
                               ItemsSource="{Binding Source={domain:EnumValueBindingSource {x:Type alignment:AlignmentBehaviourEnum}}}" 
                               SelectedItem="{Binding AlignmentBehaviour}"
                               Style="{StaticResource MaterialDesignFloatingHintComboBox}">
-                        <ComboBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel />
-                            </ItemsPanelTemplate>
-                        </ComboBox.ItemsPanel>
-                    </ComboBox>
-                    <StackPanel Grid.Row="2" Grid.Column="0"  Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="20,0,5,20">
-                        <md:PopupBox  StaysOpen="False" IsEnabled="true" VerticalAlignment="Bottom" Width="24" HorizontalAlignment="Left" ToolTip="{StaticResource skyReset}">
-                            <Grid Width="150">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="30" />
-                                    <RowDefinition Height="40" />
-                                </Grid.RowDefinitions>
-                                <Label Grid.Row="0" HorizontalAlignment="Center" Content="{StaticResource SkyResetDef}"/>
-                                <Button Grid.Row="1" HorizontalAlignment="Center" Content="{StaticResource diaAccept}" 
+                                <ComboBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <VirtualizingStackPanel />
+                                    </ItemsPanelTemplate>
+                                </ComboBox.ItemsPanel>
+                            </ComboBox>
+                            <StackPanel Grid.Row="2" Grid.Column="0"  Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="20,0,5,20">
+                                <md:PopupBox  StaysOpen="False" IsEnabled="true" VerticalAlignment="Bottom" Width="24" HorizontalAlignment="Left" ToolTip="{StaticResource skyReset}">
+                                    <Grid Width="150">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="30" />
+                                            <RowDefinition Height="40" />
+                                        </Grid.RowDefinitions>
+                                        <Label Grid.Row="0" HorizontalAlignment="Center" Content="{StaticResource SkyResetDef}"/>
+                                        <Button Grid.Row="1" HorizontalAlignment="Center" Content="{StaticResource diaAccept}" 
                                         Style="{StaticResource MaterialDesignRaisedButton}" Command="{Binding ResetProximityLimit}"/>
-                            </Grid>
-                        </md:PopupBox>
-                        <TextBox Grid.Row="2" Grid.Column="0"  Width="110" IsReadOnly="True"
+                                    </Grid>
+                                </md:PopupBox>
+                                <TextBox Grid.Row="2" Grid.Column="0"  Width="110" IsReadOnly="True"
                                  md:HintAssist.Hint="{StaticResource optProximityLimit}" 
                                  Text="{Binding ProximityLimitArcSeconds}"
                                  ToolTip="{StaticResource aliProximityLimitTooltip}"
                                  Style="{StaticResource MaterialDesignFloatingHintTextBox}" domain:TextBoxMaskBehaviour.Mask="Decimal" />
-                    </StackPanel>
-                    <Slider Grid.Row="2" Grid.Column="2" Value="{Binding ProximityLimitArcSeconds}" 
+                            </StackPanel>
+                            <Slider Grid.Row="2" Grid.Column="2" Value="{Binding ProximityLimitArcSeconds}" 
                             Style="{StaticResource MaterialDesignDiscreteVerticalSlider}"
                             ToolTip="{StaticResource aliProximityLimitTooltip}"
                             Width="75"
@@ -85,144 +87,160 @@
                             TickFrequency="200"
                             TickPlacement="None" />
 
-                    <ComboBox Grid.Row="3" md:HintAssist.Hint="{StaticResource optActivePoints}" 
+                            <ComboBox Grid.Row="3" md:HintAssist.Hint="{StaticResource optActivePoints}" 
                               MinWidth="10" Margin="20,0,5,20" Width="200" 
                               HorizontalAlignment="Left" VerticalAlignment="Top" 
                               ToolTip="{StaticResource aliActivePointsTooltip}" 
                               ItemsSource="{Binding Source={domain:EnumValueBindingSource {x:Type alignment:ActivePointsEnum}}}" 
                               SelectedItem="{Binding ActivePoints}"
                               Style="{StaticResource MaterialDesignFloatingHintComboBox}">
-                        <ComboBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel />
-                            </ItemsPanelTemplate>
-                        </ComboBox.ItemsPanel>
-                    </ComboBox>
-                    <ComboBox Grid.Row="4" md:HintAssist.Hint="{StaticResource optThreePointAlgorithm}" 
+                                <ComboBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <VirtualizingStackPanel />
+                                    </ItemsPanelTemplate>
+                                </ComboBox.ItemsPanel>
+                            </ComboBox>
+                            <ComboBox Grid.Row="4" md:HintAssist.Hint="{StaticResource optThreePointAlgorithm}" 
                               MinWidth="10" Margin="20,0,5,20" Width="200" 
                               HorizontalAlignment="Left" VerticalAlignment="Top" 
                               ToolTip="{StaticResource aliThreePointAlgorithmTooltip}" 
                               ItemsSource="{Binding Source={domain:EnumValueBindingSource {x:Type alignment:ThreePointAlgorithmEnum}}}"
                               SelectedItem="{Binding ThreePointAlgorithm}"
                               Style="{StaticResource MaterialDesignFloatingHintComboBox}">
-                        <ComboBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel />
-                            </ItemsPanelTemplate>
-                        </ComboBox.ItemsPanel>
-                    </ComboBox>
-                    <StackPanel Grid.Row="5" Grid.ColumnSpan="3" Grid.Column="0" Orientation="Horizontal" Margin="20,0,5,20">
-                        <ToggleButton Style="{StaticResource MaterialDesignActionLightToggleButton}" HorizontalAlignment="Center"  Margin="12,0,0,0"  Width="25" Height="25" ToolTip="{StaticResource aliClearModelOnStartupTooltip}"
-                                      IsChecked="{Binding ClearModelOnStartup, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <Label VerticalAlignment="Bottom" HorizontalAlignment="Center" Content="{StaticResource aliClearModelOnStartup}"/>
-                    </StackPanel>
+                                <ComboBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <VirtualizingStackPanel />
+                                    </ItemsPanelTemplate>
+                                </ComboBox.ItemsPanel>
+                            </ComboBox>
+                            <ComboBox Grid.Row="5" md:HintAssist.Hint="{StaticResource optAlignmentWarningThreshold}" 
+                              MinWidth="10" Margin="20,0,5,0" 
+                              HorizontalAlignment="Left" VerticalAlignment="Top"  
+                              ToolTip="{StaticResource aliWarningThresholdTooltip}"
+                              ItemsSource="{Binding AlignmentWarningThresholdList}"
+                              SelectedItem="{Binding AlignmentWarningThreshold, UpdateSourceTrigger=PropertyChanged}"
+                              Style="{StaticResource MaterialDesignFloatingHintComboBox}">
+                                <ComboBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <VirtualizingStackPanel />
+                                    </ItemsPanelTemplate>
+                                </ComboBox.ItemsPanel>
+                            </ComboBox>
 
-                </Grid>
-            </md:DrawerHost.LeftDrawerContent>
-            <Grid Margin="5,5" >
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
-                    <ToggleButton HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="False" x:Name="MenuToggleButton" ToolTip="{StaticResource aliOpenTooltip}" 
+                            <StackPanel Grid.Row="6" Grid.ColumnSpan="3" Grid.Column="0" Orientation="Horizontal" Margin="20,0,5,20">
+                                <ToggleButton Style="{StaticResource MaterialDesignActionLightToggleButton}" HorizontalAlignment="Center"  Margin="12,0,0,0"  Width="25" Height="25" ToolTip="{StaticResource aliClearModelOnStartupTooltip}"
+                                      IsChecked="{Binding ClearModelOnStartup, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <Label VerticalAlignment="Bottom" HorizontalAlignment="Center" Content="{StaticResource aliClearModelOnStartup}"/>
+                            </StackPanel>
+
+                        </Grid>
+                    </ScrollViewer>
+                </md:DrawerHost.LeftDrawerContent>
+                <Grid Margin="5,5" >
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="40" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
+                        <ToggleButton HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="False" x:Name="MenuToggleButton" ToolTip="{StaticResource aliOpenTooltip}" 
                                   Command="{x:Static md:DrawerHost.OpenDrawerCommand}" CommandParameter="{x:Static Dock.Left}" IsHitTestVisible="True" 
                                   Style="{StaticResource MaterialDesignHamburgerToggleButton}"/>
-                    <StackPanel Orientation="Horizontal" Margin="10 0" Visibility="{Binding IsAlertOn, Converter={StaticResource InverseBoolToVisConverter}}" >
-                        <ToggleButton Style="{StaticResource MaterialDesignActionLightToggleButton}"
+                        <StackPanel Orientation="Horizontal" Margin="10 0" Visibility="{Binding IsAlertOn, Converter={StaticResource InverseBoolToVisConverter}}" >
+                            <ToggleButton Style="{StaticResource MaterialDesignActionLightToggleButton}"
                                   HorizontalAlignment="Center" Width="25" Height="25"  IsHitTestVisible="True"
                                   IsChecked="{Binding IsAlignmentOn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                   ToolTip="{StaticResource aliAlignmentOnTooltip}"/>
-                        <Label  VerticalAlignment="Center" Content="{StaticResource aliAlignmentOn}"/>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="10 0" Visibility="{Binding IsAlertOn, Converter={StaticResource BooleanToVisibilityConverter}}" >
-                        <Button Height="30"  Foreground="Gold"
+                            <Label  VerticalAlignment="Center" Content="{StaticResource aliAlignmentOn}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="10 0" Visibility="{Binding IsAlertOn, Converter={StaticResource BooleanToVisibilityConverter}}" >
+                            <Button Height="30"  Foreground="Gold"
                             ToolTip="{StaticResource aliCancelAlertTooltip}"  VerticalAlignment="Center" Style="{StaticResource MaterialDesignRaisedDarkButton}" Command="{Binding CancelAlertCommand}"
                             Content="{StaticResource aliCancelAlert}"/>
-                    </StackPanel>
-                    <Button Margin="15,0,0,0" Height="30"
+                        </StackPanel>
+                        <Button Margin="15,0,0,0" Height="30"
                             ToolTip="{StaticResource aliClearAllTooltip}"  VerticalAlignment="Center" Style="{StaticResource MaterialDesignRaisedDarkButton}" Command="{Binding ClearAllPointsCommand}"
                             Content="{StaticResource aliClearAll}"/>
-                    <Button Margin="10,0,0,0" Height="30" 
+                        <Button Margin="10,0,0,0" Height="30" 
                             ToolTip="{StaticResource aliDeleteTooltip}" Style="{StaticResource MaterialDesignRaisedDarkButton}" Command="{Binding DeleteSelectedPointCommand}"
                             Content="{StaticResource aliDelete}"/>
-                </StackPanel>
-                <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Margin="0,0,0,0" Height="30" HorizontalAlignment="Right"
+                    </StackPanel>
+                    <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Margin="0,0,0,0" Height="30" HorizontalAlignment="Right"
                                 ToolTip="{StaticResource aliExportTooltip}"  VerticalAlignment="Center" Style="{StaticResource MaterialDesignRaisedDarkButton}" Command="{Binding ExportCommand}"
                                 Content="{StaticResource aliExport}"/>
-                    <Button Margin="10,0,10,0" Height="30" HorizontalAlignment="Right"
+                        <Button Margin="10,0,10,0" Height="30" HorizontalAlignment="Right"
                                 ToolTip="{StaticResource aliImportTooltip}" Style="{StaticResource MaterialDesignRaisedDarkButton}" Command="{Binding ImportCommand}"
                                 Content="{StaticResource aliImport}"/>
 
-                </StackPanel>
-                <TabControl Grid.Row="1" Grid.ColumnSpan="2" Grid.Column="0" HorizontalAlignment="Stretch" Background="Transparent">
-                    <TabItem Header="Data" >
-                        <DataGrid 
+                    </StackPanel>
+                    <TabControl Grid.Row="1" Grid.ColumnSpan="2" Grid.Column="0" HorizontalAlignment="Stretch" Background="Transparent">
+                        <TabItem Header="Data" >
+                            <DataGrid 
                           ItemsSource="{Binding AlignmentPoints}" 
                           SelectedItem="{Binding DataContext.SelectedAlignmentPoint, RelativeSource={RelativeSource AncestorType=alignment:AlignmentV}}"
                           CanUserAddRows="False"
                           CanUserDeleteRows="False"
                           AutoGenerateColumns="False"
                           >
-                            <DataGrid.Resources>
-                                <Style x:Key="RightAlignedGridHeaderStyle" TargetType="DataGridColumnHeader" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}">
-                                    <Setter Property="HorizontalContentAlignment" Value="Right"/>
-                                </Style>
-                            </DataGrid.Resources>
-                            <DataGrid.RowStyle>
-                                <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MaterialDesignDataGridRow}">
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Selected}" Value="true">
-                                            <Setter Property="FontWeight" Value="ExtraBold"></Setter>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding Selected}" Value="false">
-                                            <Setter Property="FontWeight" Value="Normal"></Setter>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </DataGrid.RowStyle>
-                            <DataGrid.CellStyle>
-                                <Style TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource MaterialDesignDataGridCell}">
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding SelectedForGoto}" Value="true">
-                                            <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </DataGrid.CellStyle>
+                                <DataGrid.Resources>
+                                    <Style x:Key="RightAlignedGridHeaderStyle" TargetType="DataGridColumnHeader" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}">
+                                        <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                                    </Style>
+                                </DataGrid.Resources>
+                                <DataGrid.RowStyle>
+                                    <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MaterialDesignDataGridRow}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Selected}" Value="true">
+                                                <Setter Property="FontWeight" Value="ExtraBold"></Setter>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Selected}" Value="false">
+                                                <Setter Property="FontWeight" Value="Normal"></Setter>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGrid.RowStyle>
+                                <DataGrid.CellStyle>
+                                    <Style TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource MaterialDesignDataGridCell}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding SelectedForGoto}" Value="true">
+                                                <Setter Property="Foreground" Value="{DynamicResource SecondaryHueMidBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGrid.CellStyle>
 
-                            <DataGrid.Columns>
-                                <!-- Ordinal formatting left in for reference -->
-                                <!--<DataGridTemplateColumn Header="#" CellTemplate="{StaticResource OrdinalColumnDataTemplate}" HeaderStyle="{StaticResource RightAlignedGridHeaderStyle}" IsReadOnly="True"/>-->
-                                <DataGridTextColumn Header="###" Binding="{Binding Id, StringFormat='{}{0:D3}'}"  HeaderStyle="{StaticResource RightAlignedGridHeaderStyle}" IsReadOnly="True"/>
-                                <DataGridTextColumn Header="Unsynced RA" Binding="{Binding Unsynced[0], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
-                                <DataGridTextColumn Header="Unsynced Dec" Binding="{Binding Unsynced[1], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
-                                <DataGridTextColumn Header="Synced RA" Binding="{Binding Synced[0], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
-                                <DataGridTextColumn Header="Synced Dec" Binding="{Binding Synced[1], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
-                                <DataGridTextColumn Header="Diff" Binding="{Binding OffsetDistance, StringFormat='{}{0:F0}'}" IsReadOnly="True" />
-                                <DataGridTextColumn Header="Synched" Binding="{Binding SyncedTime}" IsReadOnly="True" />
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
-                    <TabItem Header="Chart" >
-                        <Grid>
-                            <lvc:CartesianChart Series="{Binding ChartData}"
+                                <DataGrid.Columns>
+                                    <!-- Ordinal formatting left in for reference -->
+                                    <!--<DataGridTemplateColumn Header="#" CellTemplate="{StaticResource OrdinalColumnDataTemplate}" HeaderStyle="{StaticResource RightAlignedGridHeaderStyle}" IsReadOnly="True"/>-->
+                                    <DataGridTextColumn Header="###" Binding="{Binding Id, StringFormat='{}{0:D3}'}"  HeaderStyle="{StaticResource RightAlignedGridHeaderStyle}" IsReadOnly="True"/>
+                                    <DataGridTextColumn Header="Unsynced RA" Binding="{Binding Unsynced[0], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
+                                    <DataGridTextColumn Header="Unsynced Dec" Binding="{Binding Unsynced[1], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
+                                    <DataGridTextColumn Header="Synced RA" Binding="{Binding Synced[0], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
+                                    <DataGridTextColumn Header="Synced Dec" Binding="{Binding Synced[1], StringFormat='{}{0:F4}'}" IsReadOnly="True" />
+                                    <DataGridTextColumn Header="Diff" Binding="{Binding OffsetDistance, StringFormat='{}{0:F0}'}" IsReadOnly="True" />
+                                    <DataGridTextColumn Header="Synched" Binding="{Binding SyncedTime}" IsReadOnly="True" />
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </TabItem>
+                        <TabItem Header="Chart" >
+                            <Grid>
+                                <lvc:CartesianChart Series="{Binding ChartData}"
                                             XAxes="{Binding ChartXAxes}"
                                             YAxes="{Binding ChartYAxes}"
                                             DrawMargin="{Binding ChartMargin}"
                                             EasingFunction="{x:Null}"
                                             TooltipPosition="Hidden"
                                             ZoomMode="None">
-                            </lvc:CartesianChart>
-                        </Grid>
-                    </TabItem>
-                </TabControl>
-            </Grid>
-        </md:DrawerHost>
-    </Grid>
+                                </lvc:CartesianChart>
+                            </Grid>
+                        </TabItem>
+                    </TabControl>
+                </Grid>
+            </md:DrawerHost>
+        </Grid>
+    </md:DialogHost>
 </UserControl>

--- a/GS.Server/Alignment/AlignmentVM.cs
+++ b/GS.Server/Alignment/AlignmentVM.cs
@@ -159,6 +159,21 @@ namespace GS.Server.Alignment
 
         }
 
+        public IList<int> AlignmentWarningThresholdList { get; }
+
+
+        public int AlignmentWarningThreshold
+        {
+            get => AlignmentSettings.AlignmentWarningThreshold;
+            set
+            {
+                AlignmentSettings.AlignmentWarningThreshold = value;
+                OnPropertyChanged();
+                AlignmentSettings.Save();
+            }
+
+        }
+
 
         public bool ClearModelOnStartup
         {
@@ -280,6 +295,8 @@ namespace GS.Server.Alignment
 
         public AlignmentVM()
         {
+            AlignmentWarningThresholdList = new List<int>(Enumerable.Range(1, 10));
+
             var monitorItem = new MonitorEntry
             {
                 Datetime = HiResDateTime.UtcNow,

--- a/GS.Server/App.config
+++ b/GS.Server/App.config
@@ -14,6 +14,32 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
     <userSettings>
+        <GS.Server.Properties.Alignment>
+            <setting name="IsAlignmentOn" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="ProximityLimit" serializeAs="String">
+                <value>0.27777777</value>
+            </setting>
+            <setting name="ClearModelOnStartup" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="Version" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="AlignmentBehaviour" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="ActivePoints" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="ThreePointAlgorithm" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="AlignmentWarningThreshold" serializeAs="String">
+                <value>2</value>
+            </setting>
+        </GS.Server.Properties.Alignment>
         <GS.Server.Properties.Focuser>
             <setting name="DeviceId" serializeAs="String">
                 <value />

--- a/GS.Server/Properties/Alignment.Designer.cs
+++ b/GS.Server/Properties/Alignment.Designer.cs
@@ -12,7 +12,7 @@ namespace GS.Server.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.5.0.0")]
     internal sealed partial class Alignment : global::System.Configuration.ApplicationSettingsBase {
         
         private static Alignment defaultInstance = ((Alignment)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Alignment())));
@@ -104,6 +104,18 @@ namespace GS.Server.Properties {
             }
             set {
                 this["ThreePointAlgorithm"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("2")]
+        public int AlignmentWarningThreshold {
+            get {
+                return ((int)(this["AlignmentWarningThreshold"]));
+            }
+            set {
+                this["AlignmentWarningThreshold"] = value;
             }
         }
     }

--- a/GS.Server/Properties/Alignment.settings
+++ b/GS.Server/Properties/Alignment.settings
@@ -23,5 +23,8 @@
     <Setting Name="ThreePointAlgorithm" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="AlignmentWarningThreshold" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">2</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/GS.Server/SkyTelescope/SkyServer.cs
+++ b/GS.Server/SkyTelescope/SkyServer.cs
@@ -1102,7 +1102,7 @@ namespace GS.Server.SkyTelescope
             set
             {
                 _steps = value;
-                
+
                 //Implement Pec
                 PecCheck();
 
@@ -1285,7 +1285,7 @@ namespace GS.Server.SkyTelescope
                 }
                 else
                 {
-                    if (TrackingSpeak && _trackingMode != TrackingMode.Off){Synthesizer.Speak(Application.Current.Resources["vceTrackingOff"].ToString());}
+                    if (TrackingSpeak && _trackingMode != TrackingMode.Off) { Synthesizer.Speak(Application.Current.Resources["vceTrackingOff"].ToString()); }
                     _trackingMode = TrackingMode.Off;
                     IsPulseGuidingDec = false; // Ensure pulses are off
                     IsPulseGuidingRa = false;
@@ -1307,7 +1307,7 @@ namespace GS.Server.SkyTelescope
         /// <returns></returns>
         private static int SimGoTo(double[] target, bool trackingState)
         {
-            
+
             var monitorItem = new MonitorEntry
             {
                 Datetime = HiResDateTime.UtcNow,
@@ -1749,9 +1749,9 @@ namespace GS.Server.SkyTelescope
 
             change += SkyTrackingRate; // Tracking
             change += SkyHCRate; // Hand controller
-            
+
             if (Math.Abs(RateMoveAxisRa) > 0)// MoveAxis RA absolute at the given rate
-            {change.X += RateMoveAxisRa; }
+            { change.X += RateMoveAxisRa; }
             else
             { change.X += GetRaRateDirection(RateRa); }
 
@@ -2307,7 +2307,7 @@ namespace GS.Server.SkyTelescope
 
         #endregion
 
-         #region Shared Mount Items
+        #region Shared Mount Items
 
         /// <summary>
         /// Abort Slew in a normal motion
@@ -2329,8 +2329,8 @@ namespace GS.Server.SkyTelescope
             MonitorLog.LogToMonitor(monitorItem);
 
             //IsSlewing = false;
-            _rateMoveAxes = new Vector(0,0);
-            _rateRaDec = new Vector(0,0);
+            _rateMoveAxes = new Vector(0, 0);
+            _rateRaDec = new Vector(0, 0);
             SlewState = SlewType.SlewNone;
             var tracking = Tracking;
             Tracking = false; //added back in for spec "Tracking is returned to its pre-slew state"
@@ -3021,7 +3021,7 @@ namespace GS.Server.SkyTelescope
 
             return rate;
         }
-        
+
         public static ParkPosition GetStoredParkPosition()
         {
             var p = new ParkPosition { Name = SkySettings.ParkName, X = SkySettings.ParkAxisX, Y = SkySettings.ParkAxisY };
@@ -3185,7 +3185,7 @@ namespace GS.Server.SkyTelescope
         /// <returns></returns>
         private static void UpdateSteps()
         {
-            if (!IsMountRunning){ return; }
+            if (!IsMountRunning) { return; }
 
             object _;
             switch (SkySettings.Mount)
@@ -4520,7 +4520,7 @@ namespace GS.Server.SkyTelescope
                     break;
                 case MountType.SkyWatcher:
                     SkyTrackingRate.X = rateChange;
-                    var rate =  SkyGetRate();
+                    var rate = SkyGetRate();
                     _ = new SkyAxisSlew(0, AxisId.Axis1, rate.X);
                     break;
                 default:
@@ -4590,7 +4590,7 @@ namespace GS.Server.SkyTelescope
             // Check Forced flip for a goto
             var flipGoto = FlipOnNextGoto;
             FlipOnNextGoto = false;
-            
+
             // See if the target is within flip angle limits
             if (!IsWithinFlipLimits(position)) { return null; }
             var alt = Axes.GetAltAxisPosition(position);
@@ -4611,7 +4611,7 @@ namespace GS.Server.SkyTelescope
                 };
                 MonitorLog.LogToMonitor(monitorItem);
             }
-            
+
             if (cl != "b") { return null; }
 
             switch (SkySettings.Mount)
@@ -4748,8 +4748,8 @@ namespace GS.Server.SkyTelescope
             };
             MonitorLog.LogToMonitor(monitorItem);
 
-            _rateMoveAxes = new Vector(0,0);
-            _rateRaDec = new Vector(0,0);
+            _rateMoveAxes = new Vector(0, 0);
+            _rateRaDec = new Vector(0, 0);
             SlewState = SlewType.SlewNone;
 
             if (!AxesStopValidate())
@@ -5045,7 +5045,7 @@ namespace GS.Server.SkyTelescope
         /// <returns></returns>
         private static double[] GetSyncedAxes(double[] unsynced)
         {
-            if (AlignmentModel.IsAlignmentOn && SkyServer.SlewState== SlewType.SlewRaDec && !SkyServer.IsHome && !SkyServer.AtPark)
+            if (AlignmentModel.IsAlignmentOn && SkyServer.SlewState == SlewType.SlewRaDec && !SkyServer.IsHome && !SkyServer.AtPark)
             {
                 double[] synced = AlignmentModel.GetSyncedValue(unsynced);
                 var monitorItem = new MonitorEntry
@@ -5061,10 +5061,10 @@ namespace GS.Server.SkyTelescope
                 MonitorLog.LogToMonitor(monitorItem);
 
                 // For safety, check the difference is within the max unsynced/synched difference found in the alignment model.
-                var a = Math.Abs(unsynced[0]) - Math.Abs(synced[0]);
-                var b = Math.Abs(unsynced[1]) - Math.Abs(synced[1]);
+                var a = Math.Abs(unsynced[0] - synced[0]);
+                var b = Math.Abs(unsynced[1] - synced[1]);
                 double[] maxDelta = AlignmentModel.MaxDelta;
-                if (Math.Abs(a) > maxDelta[0] || Math.Abs(b) > maxDelta[1])
+                if (Math.Abs(a) > maxDelta[0] * AlignmentModel.AlignmentWarningThreshold || Math.Abs(b) > maxDelta[1] * AlignmentModel.AlignmentWarningThreshold)
                 {
                     // Log a warning message, switch off the alignment model and return the original calculated position.
                     monitorItem = new MonitorEntry
@@ -5075,7 +5075,7 @@ namespace GS.Server.SkyTelescope
                         Type = MonitorType.Warning,
                         Method = MethodBase.GetCurrentMethod()?.Name,
                         Thread = Thread.CurrentThread.ManagedThreadId,
-                        Message = $"{unsynced[0]}|{unsynced[1]}|{synced[0]}|{synced[1]}|{maxDelta[0]}|{maxDelta[1]}"
+                        Message = $"Large delta: {unsynced[0]}|{unsynced[1]}|{synced[0]}|{synced[1]}|{maxDelta[0]}|{maxDelta[1]}"
                     };
                     MonitorLog.LogToMonitor(monitorItem);
                     AlignmentSettings.IsAlertOn = true;
@@ -5104,17 +5104,17 @@ namespace GS.Server.SkyTelescope
             if (AlignmentModel.IsAlignmentOn && SkyServer.SlewState != SlewType.SlewPark && SkyServer.SlewState != SlewType.SlewHome
                 && !SkyServer.IsHome && !SkyServer.AtPark)
             {
-                var monitorItem = new MonitorEntry
-                {
-                    Datetime = HiResDateTime.UtcNow,
-                    Device = MonitorDevice.Server,
-                    Category = MonitorCategory.Alignment,
-                    Type = MonitorType.Data,
-                    Method = MethodBase.GetCurrentMethod()?.Name,
-                    Thread = Thread.CurrentThread.ManagedThreadId,
-                    Message = $"Mapped synced axis angles: {synced[0]}/{synced[1]} to {unsynced[0]}/{unsynced[1]}"
-                };
-                MonitorLog.LogToMonitor(monitorItem);
+                //var monitorItem = new MonitorEntry
+                //{
+                //    Datetime = HiResDateTime.UtcNow,
+                //    Device = MonitorDevice.Server,
+                //    Category = MonitorCategory.Alignment,
+                //    Type = MonitorType.Data,
+                //    Method = MethodBase.GetCurrentMethod()?.Name,
+                //    Thread = Thread.CurrentThread.ManagedThreadId,
+                //    Message = $"Mapped synced axis angles: {synced[0]}/{synced[1]} to {unsynced[0]}/{unsynced[1]}"
+                //};
+                //MonitorLog.LogToMonitor(monitorItem);
                 return unsynced;
             }
 
@@ -5156,6 +5156,9 @@ namespace GS.Server.SkyTelescope
                     break;
                 case "ThreePointAlgorithm":
                     AlignmentModel.ThreePointAlgorithm = AlignmentSettings.ThreePointAlgorithm;
+                    break;
+                case "AlignmentWarningThreshold":
+                    AlignmentModel.AlignmentWarningThreshold = AlignmentSettings.AlignmentWarningThreshold;
                     break;
             }
         }
@@ -5216,8 +5219,8 @@ namespace GS.Server.SkyTelescope
             PecWormMaster = null;
 
             // reset any rates so slewing doesn't start
-            _rateRaDec = new Vector(0,0);
-            _rateMoveAxes = new Vector(0,0);
+            _rateRaDec = new Vector(0, 0);
+            _rateMoveAxes = new Vector(0, 0);
             SlewState = SlewType.SlewNone;
 
             // invalid any target positions
@@ -5530,7 +5533,7 @@ namespace GS.Server.SkyTelescope
         }
 
         private static Tuple<int, double, int> _pecBinNow;
-        
+
         /// <summary>
         /// Pec Currently used bin for Pec
         /// </summary>

--- a/GS.Shared/LanguageFiles/GSServer_en-US.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_en-US.xaml
@@ -717,5 +717,10 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="btnContinuePark">Accept for Park</system:String>
     <system:String x:Key="FlipOnNextGoto">Force flip on next GoTo</system:String>
 
+    <!--1.0.6.4 -->
+    <system:String x:Key="optAlignmentWarningThreshold">Warning Threshold</system:String>
+    <system:String x:Key="aliWarningThresholdTooltip">The level at which the alignment warning is trigged (multiplier of maximum synchronisation offset distance registered).</system:String>
+
+
 </ResourceDictionary>
  

--- a/GS.Shared/LanguageFiles/GSServer_fr-FR.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_fr-FR.xaml
@@ -719,4 +719,9 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="btnContinuePark">Accepter pour se garer</system:String>
     <system:String x:Key="FlipOnNextGoto">Forcer le retournement au prochain coup</system:String>
 
+    <!--1.0.6.4 -->
+    <system:String x:Key="optAlignmentWarningThreshold">Seuil d'avertissement</system:String>
+    <system:String x:Key="aliWarningThresholdTooltip">Le niveau auquel l'avertissement d'alignement est déclenché (multiple de la distance de décalage de synchronisation maximale enregistrée).</system:String>
+
+
 </ResourceDictionary>

--- a/GS.Shared/LanguageFiles/GSServer_it-IT.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_it-IT.xaml
@@ -717,5 +717,9 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="btnContinuePark">Accetta per Park</system:String>
     <system:String x:Key="FlipOnNextGoto">Forza l'inversione alla mossa successiva</system:String>
 
+    <!--1.0.6.4 -->
+    <system:String x:Key="optAlignmentWarningThreshold">Soglia di avviso</system:String>
+    <system:String x:Key="aliWarningThresholdTooltip">Il livello al quale viene attivato l'avviso di allineamento (multiplo della distanza massima di offset di sincronizzazione registrata).</system:String>
+
 </ResourceDictionary>
  

--- a/GS.Shared/Languages/StringResServer_en-us.xaml
+++ b/GS.Shared/Languages/StringResServer_en-us.xaml
@@ -723,5 +723,11 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="btnContinueHome">Accept to slew Home</system:String>
     <system:String x:Key="btnContinuePark">Accept for Park</system:String>
     <system:String x:Key="FlipOnNextGoto">Force flip on next GoTo</system:String>
+    
+    <!--1.0.6.4 -->
+    <system:String x:Key="optAlignmentWarningThreshold">Warning Threshold</system:String>
+    <system:String x:Key="aliWarningThresholdTooltip">The level at which the alignment warning is trigged (multiplier of maximum synchronisation offset distance registered).</system:String>
+
+
 </ResourceDictionary>
  


### PR DESCRIPTION
Hi Rob,

I have added a warning threshold setting to the alignment settings. This will allow the user to control the sensitivity of the warning trigger. Bigger the number the bigger the offset allowed before triggering the warning. The number selected (1-10) is used to multiply the maximum offset entered via syncs. 

I have added new strings to the resources under a heading 1.0.6.4, if the next release is actually different to this number the comment will need updating.

Phil