### PR TITLE
Fix v1.0.8.5 gives an error when used with ASCOM 7, RC5

### DIFF
--- a/GS.Server/Model3D/Model3DVM.cs
+++ b/GS.Server/Model3D/Model3DVM.cs
@@ -423,7 +423,7 @@ namespace GS.Server.Model3D
         /// <returns></returns>
         private bool IsCurrentViewModel()
         {
-            if (SkyServer.SelectedTab.Uid != 4) { return false; }
+            if (SkyServer.SelectedTab?.Uid != 4) { return false; }
             ScreenEnabled = SkyServer.IsMountRunning;
             return true;
         }

--- a/GS.Server/PoleLocator/PoleLocatorVM.cs
+++ b/GS.Server/PoleLocator/PoleLocatorVM.cs
@@ -183,7 +183,7 @@ namespace GS.Server.PoleLocator
             {
                 // don't run if on a different viewmodel
                 if (_mainWindowVM == null) return;
-                if (_mainWindowVM.CurrentPageViewModel.Uid != 5) return;
+                if (_mainWindowVM.CurrentPageViewModel?.Uid != 5) return;
 
                 Update();
                 SetHemisphere();

--- a/GS.Server/SkyTelescope/SkyTelescopeVM.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeVM.cs
@@ -496,7 +496,7 @@ namespace GS.Server.SkyTelescope
                                     SetGraphics();
                                     break;
                                 case "Rotate3DModel":
-                                    if (SkyServer.SelectedTab.Uid != 0) { return; }
+                                    if (SkyServer.SelectedTab?.Uid != 0) { return; }
                                     Rotate();
                                     break;
                                 case "IsHome":


### PR DESCRIPTION
Check for null SelectedTab before accessing window Uid - fixes timing crash found when starting externally as COM server