### PR TITLE
Updates to cancellation of asynchronous tasks

### DIFF
--- a/GS.Principle/MediaTimer.cs
+++ b/GS.Principle/MediaTimer.cs
@@ -313,10 +313,14 @@ namespace GS.Principles
                 {
                     throw new ArgumentOutOfRangeException($"Period", value, "Multimedia Timer period out of range.");
                 }
-                _period = value;
-                if (!IsRunning) return;
-                Stop();
-                Start();
+
+                if (_period != value)
+                {
+                    _period = value;
+                    if (!IsRunning) return;
+                    Stop();
+                    Start();
+                }
             }
         }
 
@@ -453,6 +457,12 @@ namespace GS.Principles
 
             OnDisposed(EventArgs.Empty);
         }
+
+        /// <summary>
+        /// Internal timer ID
+        /// </summary>
+        public int TimerID => _timerID;
+
     }
 
     /// <summary>

--- a/GS.Server/SkyTelescope/Axes.cs
+++ b/GS.Server/SkyTelescope/Axes.cs
@@ -96,7 +96,7 @@ namespace GS.Server.SkyTelescope
                     throw new ArgumentOutOfRangeException();
             }
             var monitorItem = new MonitorEntry
-            { Datetime = HiResDateTime.UtcNow, Device = MonitorDevice.Server, Category = MonitorCategory.Server, Type = MonitorType.Data, Method = MethodBase.GetCurrentMethod()?.Name, Thread = Thread.CurrentThread.ManagedThreadId, Message = $"{axes[0]}|{axes[1]}|{a[0]}|{a[1]}" };
+            { Datetime = HiResDateTime.UtcNow, Device = MonitorDevice.Server, Category = MonitorCategory.Server, Type = MonitorType.Debug, Method = MethodBase.GetCurrentMethod()?.Name, Thread = Thread.CurrentThread.ManagedThreadId, Message = $"{axes[0]}|{axes[1]}|{a[0]}|{a[1]}" };
             MonitorLog.LogToMonitor(monitorItem);
             return a;
         }
@@ -222,7 +222,7 @@ namespace GS.Server.SkyTelescope
             axes = Range.RangeAxesXY(axes);
 
             var monitorItem = new MonitorEntry
-            { Datetime = HiResDateTime.UtcNow, Device = MonitorDevice.Server, Category = MonitorCategory.Server, Type = MonitorType.Data, Method = MethodBase.GetCurrentMethod()?.Name, Thread = Thread.CurrentThread.ManagedThreadId, Message = $"Range:{axes[0]}|{axes[1]}" };
+            { Datetime = HiResDateTime.UtcNow, Device = MonitorDevice.Server, Category = MonitorCategory.Server, Type = MonitorType.Debug, Method = MethodBase.GetCurrentMethod()?.Name, Thread = Thread.CurrentThread.ManagedThreadId, Message = $"Range:{axes[0]}|{axes[1]}" };
             MonitorLog.LogToMonitor(monitorItem);
 
             return new[] { axes[1], axes[0] };

--- a/GS.Server/SkyTelescope/AxesRateOfChange.cs
+++ b/GS.Server/SkyTelescope/AxesRateOfChange.cs
@@ -36,7 +36,7 @@ namespace GS.Server.SkyTelescope
                     var deltaTime = (double)(_currentTicks - _previousTicks) / TimeSpan.TicksPerSecond;
                     return (_currentAxisAngles - _previousAxisAngles) / deltaTime;
                 }
-                return new Vector(0.0, 0.0);
+                return new Vector(999, 999);
             }
         }
 
@@ -57,7 +57,7 @@ namespace GS.Server.SkyTelescope
         /// <summary>
         /// 
         /// </summary>
-        private static void Reset()
+        public static void Reset()
         {
             _currentAxisAngles = new Vector(0.0, 0.0);
             _previousAxisAngles = new Vector(0.0, 0.0);

--- a/GS.Server/SkyTelescope/SkyPredictor.cs
+++ b/GS.Server/SkyTelescope/SkyPredictor.cs
@@ -120,7 +120,7 @@ namespace GS.Server.SkyTelescope
                 Type = MonitorType.Debug,
                 Method = "P." + MethodBase.GetCurrentMethod()?.Name,
                 Thread = Thread.CurrentThread.ManagedThreadId,
-                Message = $"{ReferenceTime}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
+                Message = $"{ReferenceTime:yyyy-mm-dd H:mm:ss}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
             };
             MonitorLog.LogToMonitor(monitorItem);
 
@@ -149,7 +149,7 @@ namespace GS.Server.SkyTelescope
                 Type = MonitorType.Debug,
                 Method = "P." + MethodBase.GetCurrentMethod()?.Name,
                 Thread = Thread.CurrentThread.ManagedThreadId,
-                Message = $"{ReferenceTime}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
+                Message = $"{ReferenceTime:yyyy-mm-dd H:mm:ss}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
             };
             MonitorLog.LogToMonitor(monitorItem);
 
@@ -194,7 +194,7 @@ namespace GS.Server.SkyTelescope
                 Type = MonitorType.Debug,
                 Method = "P." + MethodBase.GetCurrentMethod()?.Name,
                 Thread = Thread.CurrentThread.ManagedThreadId,
-                Message = $"{ReferenceTime}|{result[0]}|{result[1]}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
+                Message = $"{ReferenceTime:yyyy-mm-dd H:mm:ss}|{result[0]}|{result[1]}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
             };
             MonitorLog.LogToMonitor(monitorItem);
 
@@ -235,7 +235,7 @@ namespace GS.Server.SkyTelescope
                 Type = MonitorType.Debug,
                 Method = "P." + MethodBase.GetCurrentMethod()?.Name,
                 Thread = Thread.CurrentThread.ManagedThreadId,
-                Message = $"{ReferenceTime}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
+                Message = $"{ReferenceTime:yyyy-mm-dd H:mm:ss}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
             };
             MonitorLog.LogToMonitor(monitorItem);
         }
@@ -263,7 +263,7 @@ namespace GS.Server.SkyTelescope
                 Type = MonitorType.Debug,
                 Method = "P." + MethodBase.GetCurrentMethod()?.Name,
                 Thread = Thread.CurrentThread.ManagedThreadId,
-                Message = $"{ReferenceTime}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
+                Message = $"{ReferenceTime:yyyy-mm-dd H:mm:ss}|{_ra}|{_dec}|{_rateRa}|{_rateDec}"
             };
             MonitorLog.LogToMonitor(monitorItem);
         }

--- a/GS.Server/SkyTelescope/SkyTelescopeVM.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeVM.cs
@@ -375,7 +375,9 @@ namespace GS.Server.SkyTelescope
                          Graphic = SkySettings.FrontGraphic;
                          break;
                      case "TrackingRate":
-                         TrackingRate = SkySettings.TrackingRate;
+                         _trackingRate = SkySettings.TrackingRate;
+                         SetTrackingIcon(SkySettings.TrackingRate);
+                         OnPropertyChanged("TrackingRate");
                          break;
                      case "ParkLimitName":
                          SetParkLimitSelection(SkySettings.ParkLimitName);
@@ -510,9 +512,10 @@ namespace GS.Server.SkyTelescope
                                     break;
                                 case "IsSlewing":
                                     IsSlewing = SkyServer.IsSlewing;
+                                    IsTracking = SkyServer.Tracking || SkyServer.SlewState == SlewType.SlewRaDec;
                                     break;
                                 case "Tracking":
-                                    IsTracking = SkyServer.Tracking;
+                                    IsTracking = SkyServer.Tracking || SkyServer.SlewState == SlewType.SlewRaDec;
                                     break;
                                 case "IsSideOfPier":
                                     IsSideOfPier = SkyServer.IsSideOfPier;
@@ -6680,7 +6683,7 @@ namespace GS.Server.SkyTelescope
                     Device = MonitorDevice.UI,
                     Category = MonitorCategory.Interface,
                     Type = MonitorType.Information,
-                    Method = "ScheduleAction",
+                    Method = MonitorLog.GetCurrentMethod(),
                     Thread = Thread.CurrentThread.ManagedThreadId,
                     Message = $"{action.Method}"
                 };
@@ -6701,7 +6704,7 @@ namespace GS.Server.SkyTelescope
                     Device = MonitorDevice.UI,
                     Category = MonitorCategory.Interface,
                     Type = MonitorType.Information,
-                    Method = "ScheduleAction",
+                    Method = MonitorLog.GetCurrentMethod(),
                     Thread = Thread.CurrentThread.ManagedThreadId,
                     Message = $"{ex.Message}|{ex.StackTrace}"
                 };
@@ -6715,7 +6718,7 @@ namespace GS.Server.SkyTelescope
                     Device = MonitorDevice.UI,
                     Category = MonitorCategory.Interface,
                     Type = MonitorType.Information,
-                    Method = "ScheduleAction",
+                    Method = MonitorLog.GetCurrentMethod(),
                     Thread = Thread.CurrentThread.ManagedThreadId,
                     Message = $"{ex.Message}|{ex.StackTrace}"
                 };

--- a/GS.Server/Windows/ButtonsControlVM.cs
+++ b/GS.Server/Windows/ButtonsControlVM.cs
@@ -49,7 +49,7 @@ namespace GS.Server.Windows
                     ParkSelectionSetting = ParkPositions.FirstOrDefault();
                     AtPark = SkyServer.AtPark;
                     IsHome = SkyServer.IsHome;
-                    IsTracking = SkyServer.Tracking;
+                    IsTracking = SkyServer.Tracking || SkyServer.SlewState == SlewType.SlewRaDec;
                     TrackingRate = SkySettings.TrackingRate;
                     _skyTelescopeVM.TrackingRate = SkySettings.TrackingRate;
 
@@ -148,7 +148,7 @@ namespace GS.Server.Windows
                          ScreenEnabled = SkyServer.IsMountRunning;
                          break;
                      case "Tracking":
-                         IsTracking = SkyServer.Tracking;
+                         IsTracking = SkyServer.Tracking || SkyServer.SlewState == SlewType.SlewRaDec;
                          break;
                      case "ParkSelected":
                          ParkSelection = SkyServer.ParkSelected;
@@ -1975,6 +1975,18 @@ namespace GS.Server.Windows
                 if (_isHomeDialogOpen == value) return;
                 _isHomeDialogOpen = value;
                 CloseDialogs(value);
+                OnPropertyChanged();
+            }
+        }
+
+        private object _homeContent;
+        public object HomeContent
+        {
+            get => _homeContent;
+            set
+            {
+                if (_homeContent == value) return;
+                _homeContent = value;
                 OnPropertyChanged();
             }
         }

--- a/GS.Shared/Monitor.cs
+++ b/GS.Shared/Monitor.cs
@@ -15,6 +15,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace GS.Shared
 {
@@ -312,6 +313,16 @@ namespace GS.Shared
         public static void LogToMonitor(PulseEntry entry)
         {
             MonitorQueue.AddPulse(entry);
+        }
+
+        /// <summary>
+        /// Get name of current method using compile time function for async methods
+        /// </summary>
+        /// <param name="methodName">Method name</param>
+        /// <returns></returns>
+        public static string GetCurrentMethod([CallerMemberName] string methodName = "")
+        {
+            return methodName;
         }
 
         #endregion

--- a/GS.Simulator/Actions.cs
+++ b/GS.Simulator/Actions.cs
@@ -145,11 +145,12 @@ namespace GS.Simulator
         /// <summary>
         /// Send pulse
         /// </summary>
-        /// <param name="axis"></param>
-        /// <param name="guideRate"></param>
-        /// <param name="duration"></param>
+        /// <param name="axis">Axis 1 or 2</param>
+        /// <param name="guideRate">>Guide rate degrees, 15.041/3600*.5, negative value denotes direction</param>
+        /// <param name="duration">length of pulse in milliseconds, always positive numbers</param>
+        /// <param name="token">Token source used to cancel pulse guide operation</param>
         /// <returns></returns>
-        internal bool AxisPulse(Axis axis, double guideRate, int duration)
+        internal bool AxisPulse(Axis axis, double guideRate, int duration, CancellationToken token)
         {
             if (axis == Axis.Axis1)
             {
@@ -162,8 +163,8 @@ namespace GS.Simulator
                 MountQueue.IsPulseGuidingRa = false;
             }
 
-            var arcsecs = duration / 1000.0 * Conversions.Deg2ArcSec(Math.Abs(guideRate));
-            if (arcsecs < .0002)
+            var arcSecs = duration / 1000.0 * Conversions.Deg2ArcSec(Math.Abs(guideRate));
+            if (arcSecs < .0002)
             {
                 MountQueue.IsPulseGuidingRa = false;
                 MountQueue.IsPulseGuidingDec = false;

--- a/GS.Simulator/Commands.cs
+++ b/GS.Simulator/Commands.cs
@@ -14,6 +14,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 using System;
+using System.Threading;
 
 namespace GS.Simulator
 {
@@ -574,10 +575,11 @@ namespace GS.Simulator
         private readonly Axis _axis;
         private readonly double _guideRate;
         private readonly int _duration;
+        private readonly CancellationToken _token;
         //private readonly int _backlash;
         //private readonly double _declination;
 
-        public CmdAxisPulse(long id, Axis axis, double guideRate, int duration)
+        public CmdAxisPulse(long id, Axis axis, double guideRate, int duration, CancellationToken token)
         {
             Id = id;
             //_backlash = backlash;
@@ -586,6 +588,7 @@ namespace GS.Simulator
             _axis = axis;
             _guideRate = guideRate;
             _duration = duration;
+            _token = token;
             Successful = false;
             Result = null;
             MountQueue.AddCommand(this);
@@ -595,7 +598,7 @@ namespace GS.Simulator
         {
             try
             {
-                Result = actions.AxisPulse(_axis, _guideRate, _duration);
+                Result = actions.AxisPulse(_axis, _guideRate, _duration, _token);
                 Successful = true;
             }
             catch (Exception e)

--- a/GS.SkyApi/Sky.cs
+++ b/GS.SkyApi/Sky.cs
@@ -115,7 +115,7 @@ namespace GS.SkyApi
 
             ValidateMount();
             var validAxis = ValidateAxis(axis);
-            var command = new SkyAxisPulse(SkyQueue.NewId, validAxis, guideRate, duration, backlashSteps);
+            var command = new SkyAxisPulse(SkyQueue.NewId, validAxis, guideRate, duration, backlashSteps, new CancellationToken());
             GetResult(command);
         }
 

--- a/GS.SkyWatcher/SkyCommands.cs
+++ b/GS.SkyWatcher/SkyCommands.cs
@@ -14,6 +14,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 using System;
+using System.Threading;
 
 namespace GS.SkyWatcher
 {
@@ -108,15 +109,17 @@ namespace GS.SkyWatcher
         private readonly double _guideRate;
         private readonly int _duration;
         private readonly int _backlashSteps;
+        private readonly CancellationToken _token;
         //private readonly double _declination;
 
-        public SkyAxisPulse(long id, AxisId axis, double guideRate, int duration, int backlashSteps = 0)
+        public SkyAxisPulse(long id, AxisId axis, double guideRate, int duration, int backlashSteps, CancellationToken token)
         {
             Id = id;
             _axis = axis;
             _guideRate = guideRate;
             _duration = duration;
             _backlashSteps = backlashSteps;
+            _token = token;
             //_declination = declination;
             CreatedUtc = Principles.HiResDateTime.UtcNow;
             Successful = false;
@@ -128,7 +131,7 @@ namespace GS.SkyWatcher
         {
             try
             {
-                skyWatcher.AxisPulse(_axis, _guideRate, _duration, _backlashSteps);
+                skyWatcher.AxisPulse(_axis, _guideRate, _duration, _backlashSteps, _token);
                 Successful = true;
             }
             catch (Exception e)


### PR DESCRIPTION
Reworked cancellation of asynchronous tasks for slewing, pulse guiding and axis moves. Uses cancellation token for each type of task. Cancellation is handled by throwing an exception. All tasks are placed in try/catch/finally blocks to ensure correct clean up and termination. This code allows for an in-progress slew to be cancelled automatically when the user or and ASCOM command requires a new slew without issuing a stop/abort command.