### PR TITLE
Hand controller slew fix

### DIFF
--- a/GS.Server/GS.Server.csproj
+++ b/GS.Server/GS.Server.csproj
@@ -60,6 +60,7 @@
  </ItemGroup>
   <ItemGroup>
     <Reference Include="ReachFramework" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Speech" />
     <Reference Include="System.Windows.Forms" />

--- a/GS.Server/SkyTelescope/SkyTelescopeVM.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeVM.cs
@@ -4521,10 +4521,40 @@ namespace GS.Server.SkyTelescope
 
         private void StartSlew(SlewDirection direction)
         {
+            // No action when at park
             if (SkyServer.AtPark)
             {
+                var monitorItem = new MonitorEntry
+                {
+                    Datetime = HiResDateTime.UtcNow,
+                    Device = MonitorDevice.UI,
+                    Category = MonitorCategory.Interface,
+                    Type = MonitorType.Warning,
+                    Method = MethodBase.GetCurrentMethod()?.Name,
+                    Thread = Thread.CurrentThread.ManagedThreadId,
+                    Message = $"Hand controller movement not possible when parked"
+                };
+                MonitorLog.LogToMonitor(monitorItem);
                 return;
             }
+
+            // No action unless not currently slewing or hand control movement is already active
+            if (SkyServer.SlewState != SlewType.SlewNone && SkyServer.SlewState != SlewType.SlewHandpad)
+            {
+                var monitorItem = new MonitorEntry
+                {
+                    Datetime = HiResDateTime.UtcNow,
+                    Device = MonitorDevice.UI,
+                    Category = MonitorCategory.Interface,
+                    Type = MonitorType.Warning,
+                    Method = MethodBase.GetCurrentMethod()?.Name,
+                    Thread = Thread.CurrentThread.ManagedThreadId,
+                    Message = $"Hand controller movement not possible when slewing"
+                };
+                MonitorLog.LogToMonitor(monitorItem);
+                return;
+            }
+
             var speed = SkySettings.HcSpeed;
             switch (direction)
             {


### PR DESCRIPTION
Hand controller commands from the GUI conflict with slewing (Park, Home, GoTo etc) leading to an inconsistent slewing state. This caused later slewing commands to fail. Add warning guard to prevent hand controller commands when slewing is active