### PR TITLE
Low voltage monitoring

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,9 @@
 		<Trademark>GS Server</Trademark>
 		<NeutralLanguage>en</NeutralLanguage>
 		<Copyright>Copyright © GreenSwamp Software 2019-2025</Copyright>
-		<AssemblyVersion>1.1.0.0</AssemblyVersion>
-		<FileVersion>1.1.0.0</FileVersion>
-		<ProductVersion>1.1.0.0</ProductVersion>
-		<Version>1.1.0.0</Version>
+		<AssemblyVersion>1.1.0.1</AssemblyVersion>
+		<FileVersion>1.1.0.1</FileVersion>
+		<ProductVersion>1.1.0.1</ProductVersion>
+		<Version>1.1.0.1</Version>
 	</PropertyGroup>
 </Project>

--- a/GS.Server/SkyTelescope/SkyTelescopeVM.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeVM.cs
@@ -589,6 +589,11 @@ namespace GS.Server.SkyTelescope
                                 case "HcPulseDone":
                                     HcPulseDone = SkyServer.HcPulseDone;
                                     break;
+                                case "LowVoltageEventState":
+                                    LowVoltageEventState = SkyServer.LowVoltageEventState;
+                                    if (SkyServer.LowVoltageEventState)
+                                        OpenDialog($"{ Application.Current.Resources["LowVoltage"]}", $"{Application.Current.Resources["Stopped"]}");
+                                    break;
                             }
                         });
             }
@@ -6099,6 +6104,8 @@ namespace GS.Server.SkyTelescope
                 OnPropertyChanged();
             }
         }
+
+        private bool LowVoltageEventState { get; set; }
 
         private bool _parkedBlinker;
         public bool ParkedBlinker

--- a/GS.Shared/LanguageFiles/GSServer_de-DE.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_de-DE.xaml
@@ -765,5 +765,9 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="PlotNormalize">Entfernen Sie RA-Tracking</system:String>
     <system:String x:Key="DisableKeysOnGoTo">Direction Keys Off</system:String>
     <system:String x:Key="DisableKeysOnGoToToolTip">Disable direction keys during go to</system:String>
+
+    <!--1.1.0.1 -->
+    <system:String x:Key="Stopped">Mount stopped</system:String>
+    <system:String x:Key="LowVoltage">Voltage is low: check power supply and wiring</system:String>
 </ResourceDictionary>
  

--- a/GS.Shared/LanguageFiles/GSServer_en-US.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_en-US.xaml
@@ -765,5 +765,9 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="PlotNormalize">Remove RA Tracking</system:String>
     <system:String x:Key="DisableKeysOnGoTo">Direction Keys Off</system:String>
     <system:String x:Key="DisableKeysOnGoToToolTip">Disable direction keys during go to</system:String>
+
+    <!--1.1.0.1 -->
+    <system:String x:Key="Stopped">Mount stopped</system:String>
+    <system:String x:Key="LowVoltage">Voltage is low: check power supply and wiring</system:String>
 </ResourceDictionary>
  

--- a/GS.Shared/LanguageFiles/GSServer_fr-FR.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_fr-FR.xaml
@@ -765,4 +765,8 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="PlotNormalize">Supprimer le suivi RA</system:String>
     <system:String x:Key="DisableKeysOnGoTo">Direction Keys Off</system:String>
     <system:String x:Key="DisableKeysOnGoToToolTip">Disable direction keys during go to</system:String>
+
+    <!--1.1.0.1 -->
+    <system:String x:Key="Stopped">Mount stopped</system:String>
+    <system:String x:Key="LowVoltage">Voltage is low: check power supply and wiring</system:String>
 </ResourceDictionary>

--- a/GS.Shared/LanguageFiles/GSServer_it-IT.xaml
+++ b/GS.Shared/LanguageFiles/GSServer_it-IT.xaml
@@ -765,5 +765,9 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="PlotNormalize">Rimuovi tracciamento RA</system:String>
     <system:String x:Key="DisableKeysOnGoTo">Direction Keys Off</system:String>
     <system:String x:Key="DisableKeysOnGoToToolTip">Disable direction keys during go to</system:String>
+
+    <!--1.1.0.1 -->
+    <system:String x:Key="Stopped">Mount stopped</system:String>
+    <system:String x:Key="LowVoltage">Voltage is low: check power supply and wiring</system:String>
 </ResourceDictionary>
  

--- a/GS.Shared/Languages/StringResServer_en-us.xaml
+++ b/GS.Shared/Languages/StringResServer_en-us.xaml
@@ -765,5 +765,9 @@ along with this program.  If not, see<https://www.gnu.org/licenses/> .
     <system:String x:Key="PlotNormalize">Remove RA Tracking</system:String>
     <system:String x:Key="DisableKeysOnGoTo">Direction Keys Off</system:String>
     <system:String x:Key="DisableKeysOnGoToToolTip">Disable direction keys during go to</system:String>
+
+    <!--1.1.0.1 -->
+    <system:String x:Key="Stopped">Mount stopped</system:String>
+    <system:String x:Key="LowVoltage">Voltage is low: check power supply and wiring</system:String>
 </ResourceDictionary>
  

--- a/GS.SkyWatcher/Commands.cs
+++ b/GS.SkyWatcher/Commands.cs
@@ -448,6 +448,7 @@ namespace GS.SkyWatcher
         }
 
         private static readonly Version AzgTiAdvancedSetSupportedVersion = new Version(3, 40);
+
         /// <summary>
         /// e or X0005 Gets version of the axis
         /// </summary>
@@ -564,6 +565,8 @@ namespace GS.SkyWatcher
 
             response = CmdToMount(axis, 'f', null);
             _axesStatus[(int)axis].Response = response;
+            // Set low voltage event status
+            _axesStatus[(int)axis].LowVoltageEventState = (response[3] & 0x04) == 4;
 
             //check if at full stop = 1
             if ((response[2] & 0x01) == 0)
@@ -589,6 +592,20 @@ namespace GS.SkyWatcher
             return _axesStatus[(int)axis];
         }
 
+        /// <summary>
+        /// Retrieves the current voltage level of the controller using :qx030000.
+        /// </summary>
+        /// <remarks>This method is intended to obtain the voltage level of the controller for diagnostic
+        /// or monitoring purposes. The voltage value may vary depending on the controller's operational
+        /// state.</remarks>
+        internal double GetControllerVoltage(AxisId axis)
+        {
+            var szCmd = "030000";
+            var response = CmdToMount(axis, 'q', szCmd);
+            if (string.IsNullOrEmpty(response)) return double.NaN;
+            var voltage = StringToLong(response) / 100.0; // Convert to volts
+            return voltage;
+        }
         /// <summary>
         /// g Inquire High Speed Ratio, EQ6Pro, AZeQ5, EQ8 = 16   AZeQ6 = 32
         /// </summary>

--- a/GS.SkyWatcher/SharedResources.cs
+++ b/GS.SkyWatcher/SharedResources.cs
@@ -118,6 +118,7 @@ namespace GS.SkyWatcher
         public bool TrajectoryMode; 
         public string StepSpeed;
         public string Response;
+        public bool LowVoltageEventState;
 
         public void SetFullStop()
         {

--- a/GS.SkyWatcher/SkyCommands.cs
+++ b/GS.SkyWatcher/SkyCommands.cs
@@ -798,6 +798,39 @@ namespace GS.SkyWatcher
         }
     }
 
+    public class SkyGetControllerVoltage : ISkyCommand
+    {
+        public long Id { get; }
+        public DateTime CreatedUtc { get; }
+        public bool Successful { get; set; }
+        public Exception Exception { get; set; }
+        public dynamic Result { get; private set; }
+        private readonly AxisId _axis;
+
+        public SkyGetControllerVoltage(long id, AxisId axis)
+        {
+            Id = id;
+            _axis = axis;
+            CreatedUtc = Principles.HiResDateTime.UtcNow;
+            Successful = false;
+            SkyQueue.AddCommand(this);
+        }
+
+        public void Execute(SkyWatcher skyWatcher)
+        {
+            try
+            {
+                Result = skyWatcher.GetControllerVoltage(_axis);
+                Successful = true;
+            }
+            catch (Exception e)
+            {
+                Successful = false;
+                Exception = e;
+            }
+        }
+    }
+
     public class SkyGetRampDownRange : ISkyCommand
     {
         public long Id { get; }

--- a/GS.SkyWatcher/SkyQueue.cs
+++ b/GS.SkyWatcher/SkyQueue.cs
@@ -234,7 +234,8 @@ namespace GS.SkyWatcher
         /// <param name="serial"></param>
         /// <param name="customMount360Steps"></param>
         /// <param name="customRaWormSteps"></param>
-        public static void Start(ISerialPort serial, int[] customMount360Steps, double[] customRaWormSteps)
+        /// <param name="lowVoltageEventHandler"></param>
+        public static void Start(ISerialPort serial, int[] customMount360Steps, double[] customRaWormSteps, EventHandler lowVoltageEventHandler = null)
         {
             try
             {
@@ -250,6 +251,7 @@ namespace GS.SkyWatcher
                 var ct = _cts.Token;
 
                 _skyWatcher = new SkyWatcher();
+                _skyWatcher.LowVoltageEvent += lowVoltageEventHandler;
                 _resultsDictionary = new ConcurrentDictionary<long, ISkyCommand>();
                 _commandBlockingCollection = new BlockingCollection<ISkyCommand>();
 


### PR DESCRIPTION
Add low voltage monitoring support. Requires firmware support for enhanced ":q" and ":f" commands available from V3.45 onwards (MC015, MC019, MC020 boards). Checks axis status during movement, logs error and notifies user through UI