### PR TITLE
Reset view and 3D view binding fixes, camera restore improvements, and AutoHome logs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,9 @@
 		<Trademark>GS Server</Trademark>
 		<NeutralLanguage>en</NeutralLanguage>
 		<Copyright>Copyright © GreenSwamp Software 2019-2026</Copyright>
-		<AssemblyVersion>1.2.2.1</AssemblyVersion>
-		<FileVersion>1.2.2.1</FileVersion>
-		<ProductVersion>1.2.2.1</ProductVersion>
-		<Version>1.2.2.1</Version>
+		<AssemblyVersion>1.2.2.2</AssemblyVersion>
+		<FileVersion>1.2.2.2</FileVersion>
+		<ProductVersion>1.2.2.2</ProductVersion>
+		<Version>1.2.2.2</Version>
 	</PropertyGroup>
 </Project>

--- a/GS.Server/AutoHome/AutohomeSim.cs
+++ b/GS.Server/AutoHome/AutohomeSim.cs
@@ -134,6 +134,20 @@ namespace GS.Server.AutoHome
             if (!HasHomeSensor) return AutoHomeResult.HomeCapabilityCheckFailed;
             _ = new CmdAxisStop(0, axis);
             if (SkyServer.Tracking) SkyServer.Tracking = false;
+
+            // Capture the initialised home position as the reference baseline
+            var homeAxes = SkyServer.GetHomeAxes(SkySettings.HomeAxisX, SkySettings.HomeAxisY);
+            MonitorLog.LogToMonitor(new MonitorEntry
+            {
+                Datetime = HiResDateTime.UtcNow,
+                Device = MonitorDevice.Server,
+                Category = MonitorCategory.Server,
+                Type = MonitorType.Information,
+                Method = MethodBase.GetCurrentMethod()?.Name,
+                Thread = Thread.CurrentThread.ManagedThreadId,
+                Message = $"AutoHome initialised home position|Axis:{axis}|X:{homeAxes.X}|Y:{homeAxes.Y}"
+            });
+
             //StartCount = GetEncoderCount(axis);
             var totalMove = 0.0;
             // ReSharper disable once RedundantAssignment
@@ -255,6 +269,22 @@ namespace GS.Server.AutoHome
             // slew to home
             slewResult = SlewToHome(axis);
             if (slewResult != AutoHomeResult.Success) return slewResult;
+
+            // Log detected sensor home position vs initialised home position
+            var detectedPositions = Axes.MountAxis2Mount();
+            MonitorLog.LogToMonitor(new MonitorEntry
+            {
+                Datetime = HiResDateTime.UtcNow,
+                Device = MonitorDevice.Server,
+                Category = MonitorCategory.Server,
+                Type = MonitorType.Information,
+                Method = MethodBase.GetCurrentMethod()?.Name,
+                Thread = Thread.CurrentThread.ManagedThreadId,
+                Message = $"AutoHome sensor vs initialised home|Axis:{axis}" +
+                          $"|HomeX:{homeAxes.X}|HomeY:{homeAxes.Y}" +
+                          $"|DetectedX:{detectedPositions[0]}|DetectedY:{detectedPositions[1]}" +
+                          $"|DeltaX:{detectedPositions[0] - homeAxes.X}|DeltaY:{detectedPositions[1] - homeAxes.Y}"
+            });
 
             // Dec offset for side saddles
             if (Math.Abs(offSetDec) > 0 && axis == Axis.Axis2)

--- a/GS.Server/AutoHome/AutohomeSky.cs
+++ b/GS.Server/AutoHome/AutohomeSky.cs
@@ -158,6 +158,20 @@ namespace GS.Server.AutoHome
             if (!HasHomeSensor) { return AutoHomeResult.HomeCapabilityCheckFailed; }
             _ = new SkyAxisStop(0, axis);
             if (SkyServer.Tracking) SkyServer.Tracking = false;
+
+            // Capture the initialised home position as the reference baseline
+            var homeAxes = SkyServer.GetHomeAxes(SkySettings.HomeAxisX, SkySettings.HomeAxisY);
+            MonitorLog.LogToMonitor(new MonitorEntry
+            {
+                Datetime = HiResDateTime.UtcNow,
+                Device = MonitorDevice.Server,
+                Category = MonitorCategory.Server,
+                Type = MonitorType.Information,
+                Method = MethodBase.GetCurrentMethod()?.Name,
+                Thread = Thread.CurrentThread.ManagedThreadId,
+                Message = $"AutoHome initialised home position|Axis:{axis}|X:{homeAxes.X}|Y:{homeAxes.Y}"
+            });
+
             var totalMove = 0.0;
             // ReSharper disable once RedundantAssignment
             var clockwise = false;
@@ -284,6 +298,22 @@ namespace GS.Server.AutoHome
             // slew to home
             slewResult = SlewToHome(axis);
             if (slewResult != AutoHomeResult.Success) return slewResult;
+
+            // Log detected sensor home position vs initialised home position
+            var detectedPositions = Axes.MountAxis2Mount();
+            MonitorLog.LogToMonitor(new MonitorEntry
+            {
+                Datetime = HiResDateTime.UtcNow,
+                Device = MonitorDevice.Server,
+                Category = MonitorCategory.Server,
+                Type = MonitorType.Information,
+                Method = MethodBase.GetCurrentMethod()?.Name,
+                Thread = Thread.CurrentThread.ManagedThreadId,
+                Message = $"AutoHome sensor vs initialised home|Axis:{axis}" +
+                          $"|HomeX:{homeAxes.X}|HomeY:{homeAxes.Y}" +
+                          $"|DetectedX:{detectedPositions[0]}|DetectedY:{detectedPositions[1]}" +
+                          $"|DeltaX:{detectedPositions[0] - homeAxes.X}|DeltaY:{detectedPositions[1] - homeAxes.Y}"
+            });
 
             // Dec offset for side saddles
             if (Math.Abs(offSetDec) > 0 && axis == AxisId.Axis2)

--- a/GS.Server/Controls/BindingProxy.cs
+++ b/GS.Server/Controls/BindingProxy.cs
@@ -1,0 +1,51 @@
+﻿/* Copyright(C) 2019-2026 Rob Morgan (robert.morgan.e@gmail.com)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Windows;
+
+namespace GS.Server.Controls
+{
+    /// <summary>
+    /// A Freezable resource that relays DataContext into Freezable objects inside a 3D scene.
+    ///
+    /// The core WPF limitation: Freezable objects nested inside a Visual3D transform chain
+    /// (e.g. RotateTransform3D, AxisAngleRotation3D) have no governing FrameworkElement, so a
+    /// plain {Binding Path=Foo} on them fails with WPF binding Error 2.
+    ///
+    /// Placing this proxy in UserControl.Resources works because the UserControl itself IS a
+    /// FrameworkElement and properly inherits DataContext. Freezable-target bindings in the 3D
+    /// scene use:
+    ///   {Binding Source={StaticResource ViewModelProxy}, Path=Data.PropertyName}
+    /// which supplies an explicit Source, bypassing the broken inheritance-context lookup.
+    /// </summary>
+    public sealed class BindingProxy : Freezable
+    {
+        protected override Freezable CreateInstanceCore() => new BindingProxy();
+
+        public static readonly DependencyProperty DataProperty =
+            DependencyProperty.Register(
+                nameof(Data),
+                typeof(object),
+                typeof(BindingProxy),
+                new UIPropertyMetadata(null));
+
+        /// <summary>Gets or sets the proxied DataContext object.</summary>
+        public object Data
+        {
+            get => GetValue(DataProperty);
+            set => SetValue(DataProperty, value);
+        }
+    }
+}

--- a/GS.Server/Controls/HelixViewport3D.xaml
+++ b/GS.Server/Controls/HelixViewport3D.xaml
@@ -1,6 +1,7 @@
 ﻿<UserControl x:Class="GS.Server.Controls.HelixViewport3D"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:GS.Server.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:domain="clr-namespace:GS.Shared.Domain;assembly=GS.Shared"
              xmlns:h="http://helix-toolkit.org/wpf"
@@ -14,6 +15,15 @@
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <!--<domain:NullImageConverter x:Key="NullImage" />-->
+        <!--
+            BindingProxy relays DataContext to Freezable objects in the 3D scene.
+            RotateTransform3D / AxisAngleRotation3D are Freezables with no governing
+            FrameworkElement, causing WPF binding Error 2 with plain {Binding}.
+            Bindings on those elements use:
+                {Binding Source={StaticResource ViewModelProxy}, Path=Data.PropertyName}
+            which supplies an explicit Source and bypasses the broken lookup.
+        -->
+        <controls:BindingProxy x:Key="ViewModelProxy" Data="{Binding}" />
     </UserControl.Resources>
     <Grid>
         <h:HelixViewport3D x:Name="Viewport3d"
@@ -47,9 +57,9 @@
                 <ModelVisual3D.Transform>
                     <RotateTransform3D CenterX="0"
                                        CenterY="0"
-                                       CenterZ="{Binding BeamHalfWidth}">
+                                       CenterZ="{Binding Source={StaticResource ViewModelProxy}, Path=Data.BeamHalfWidth}">
                         <RotateTransform3D.Rotation>
-                            <AxisAngleRotation3D Angle="{Binding LowerBeamAngle}" Axis="1 0 0" />
+                            <AxisAngleRotation3D Angle="{Binding Source={StaticResource ViewModelProxy}, Path=Data.LowerBeamAngle}" Axis="1 0 0" />
                         </RotateTransform3D.Rotation>
                     </RotateTransform3D>
                 </ModelVisual3D.Transform>
@@ -64,9 +74,9 @@
                 <ModelVisual3D.Transform>
                     <RotateTransform3D CenterX="0"
                                        CenterY="0"
-                                       CenterZ="{Binding ModelPierHeight}">
+                                       CenterZ="{Binding Source={StaticResource ViewModelProxy}, Path=Data.ModelPierHeight}">
                         <RotateTransform3D.Rotation>
-                            <AxisAngleRotation3D Angle="{Binding UpperBeamAngle}" Axis="-1 0 0" />
+                            <AxisAngleRotation3D Angle="{Binding Source={StaticResource ViewModelProxy}, Path=Data.UpperBeamAngle}" Axis="-1 0 0" />
                         </RotateTransform3D.Rotation>
                     </RotateTransform3D>
                 </ModelVisual3D.Transform>
@@ -84,24 +94,24 @@
                                               OffsetY="0"
                                               OffsetZ="0" />
                         <RotateTransform3D CenterX="0"
-                                           CenterY="{Binding YAxisCentre}"
+                                           CenterY="{Binding Source={StaticResource ViewModelProxy}, Path=Data.YAxisCentre}"
                                            CenterZ="525">
                             <RotateTransform3D.Rotation>
-                                <AxisAngleRotation3D Angle="{Binding XAxisOffset}" Axis="0 0 1" />
+                                <AxisAngleRotation3D Angle="{Binding Source={StaticResource ViewModelProxy}, Path=Data.XAxisOffset}" Axis="0 0 1" />
                             </RotateTransform3D.Rotation>
                         </RotateTransform3D>
                         <RotateTransform3D CenterX="0"
-                                           CenterY="{Binding YAxisCentre}"
+                                           CenterY="{Binding Source={StaticResource ViewModelProxy}, Path=Data.YAxisCentre}"
                                            CenterZ="525">
                             <RotateTransform3D.Rotation>
-                                <AxisAngleRotation3D Angle="{Binding YAxisOffset}" Axis="0 1 0" />
+                                <AxisAngleRotation3D Angle="{Binding Source={StaticResource ViewModelProxy}, Path=Data.YAxisOffset}" Axis="0 1 0" />
                             </RotateTransform3D.Rotation>
                         </RotateTransform3D>
                         <RotateTransform3D CenterX="0"
-                                           CenterY="{Binding YAxisCentre}"
+                                           CenterY="{Binding Source={StaticResource ViewModelProxy}, Path=Data.YAxisCentre}"
                                            CenterZ="525">
                             <RotateTransform3D.Rotation>
-                                <AxisAngleRotation3D Angle="{Binding ZAxisOffset}" Axis="1 0 0" />
+                                <AxisAngleRotation3D Angle="{Binding Source={StaticResource ViewModelProxy}, Path=Data.ZAxisOffset}" Axis="1 0 0" />
                             </RotateTransform3D.Rotation>
                         </RotateTransform3D>
                     </Transform3DGroup>

--- a/GS.Server/Controls/HelixViewport3D.xaml.cs
+++ b/GS.Server/Controls/HelixViewport3D.xaml.cs
@@ -10,6 +10,9 @@ namespace GS.Server.Controls
     /// Interaction logic for HelixViewport3D.xaml.
     /// Camera sync is managed here because PerspectiveCamera is a Freezable outside
     /// the logical tree, making TwoWay XAML bindings on it unsupported by WPF.
+    /// VM→Camera: code-behind subscribes to the VM's INotifyPropertyChanged so that
+    /// runtime property changes (e.g. from OpenResetView) push through to the camera.
+    /// Camera→VM: DependencyPropertyDescriptor watchers write Helix drag updates back.
     /// </summary>
     public partial class HelixViewport3D
     {
@@ -18,6 +21,10 @@ namespace GS.Server.Controls
         private PropertyInfo _lookDirectionProp;
         private PropertyInfo _upDirectionProp;
         private PropertyInfo _positionProp;
+
+        // Names of the VM properties that map to camera state.
+        private static readonly string[] CameraPropertyNames =
+            { "LookDirection", "UpDirection", "Position" };
 
         public HelixViewport3D()
         {
@@ -30,12 +37,14 @@ namespace GS.Server.Controls
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             _camera = Viewport3d.Camera as PerspectiveCamera;
+            AttachVmWatcher(DataContext);
             SyncCameraFromViewModel();
             AttachCameraWatchers();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
+            DetachVmWatcher(DataContext);
             DetachCameraWatchers();
         }
 
@@ -45,7 +54,44 @@ namespace GS.Server.Controls
             _lookDirectionProp = null;
             _upDirectionProp = null;
             _positionProp = null;
+
+            DetachVmWatcher(e.OldValue);
+            AttachVmWatcher(e.NewValue);
+
             if (IsLoaded)
+                SyncCameraFromViewModel();
+        }
+
+        /// <summary>
+        /// Subscribes to the VM's INotifyPropertyChanged so runtime camera property
+        /// changes propagate from the VM to the physical PerspectiveCamera.
+        /// </summary>
+        private void AttachVmWatcher(object vm)
+        {
+            if (vm is INotifyPropertyChanged npc)
+                npc.PropertyChanged += OnVmPropertyChanged;
+        }
+
+        private void DetachVmWatcher(object vm)
+        {
+            if (vm is INotifyPropertyChanged npc)
+                npc.PropertyChanged -= OnVmPropertyChanged;
+        }
+
+        /// <summary>
+        /// Fires when the VM raises PropertyChanged for LookDirection, UpDirection, or Position.
+        /// Pushes the new value(s) to the physical PerspectiveCamera.
+        /// </summary>
+        private void OnVmPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            // Null/empty name means a blanket refresh; named check avoids unnecessary syncs.
+            if (e.PropertyName != null &&
+                e.PropertyName != "LookDirection" &&
+                e.PropertyName != "UpDirection" &&
+                e.PropertyName != "Position")
+                return;
+
+            if (!_syncingCamera)
                 SyncCameraFromViewModel();
         }
 

--- a/GS.Server/Model3D/Model3DVM.cs
+++ b/GS.Server/Model3D/Model3DVM.cs
@@ -325,11 +325,12 @@ namespace GS.Server.Model3D
                 var modelVm = ModelVm.Model1Vm;
                 modelVm.WinHeight = 220;
                 modelVm.WinWidth = 250;
+                // Set camera values BEFORE Show() so SyncCameraFromViewModel fires with correct data.
+                modelVm.CameraIndex = 1;
                 modelVm.Position = Position;
                 modelVm.LookDirection = LookDirection;
                 modelVm.UpDirection = UpDirection;
                 modelVm.ImageFile = ImageFile;
-                modelVm.CameraIndex = 1;
                 bWin.Show();
             }
             catch (Exception ex)
@@ -367,24 +368,17 @@ namespace GS.Server.Model3D
         {
             try
             {
-                if (Numbers.IsNaNVector3D(LookDirection) || Numbers.Is0Vector3D(LookDirection))
-                {
-                    Settings.Settings.ModelLookDirection2 = new Vector3D(-900, -1100, -400);
-                }
+                // Repair persisted settings if they are invalid before restoring.
+                if (Numbers.IsNaNVector3D(Settings.Settings.ModelLookDirection1) || Numbers.Is0Vector3D(Settings.Settings.ModelLookDirection1))
+                    Settings.Settings.ModelLookDirection1 = new Vector3D(-900, -1100, -400);
 
-                if (Numbers.IsNaNVector3D(UpDirection) || Numbers.Is0Vector3D(UpDirection))
-                {
-                    Settings.Settings.ModelUpDirection2 = new Vector3D(.35, .43, .82);
-                }
+                if (Numbers.IsNaNVector3D(Settings.Settings.ModelUpDirection1) || Numbers.Is0Vector3D(Settings.Settings.ModelUpDirection1))
+                    Settings.Settings.ModelUpDirection1 = new Vector3D(.35, .43, .82);
 
-                if (Numbers.IsNaNPoint3D(Position) || Numbers.Is0Point3D(Position))
-                {
-                    Settings.Settings.ModelPosition2 = new Point3D(900, 1100, 800);
-                }
+                if (Numbers.IsNaNPoint3D(Settings.Settings.ModelPosition1) || Numbers.Is0Point3D(Settings.Settings.ModelPosition1))
+                    Settings.Settings.ModelPosition1 = new Point3D(900, 1100, 800);
 
-                LoadTelescopeModel();
-                Rotate();
-                SetPierSideIndicator();
+                RefreshView();
             }
             catch (Exception ex)
             {
@@ -441,7 +435,24 @@ namespace GS.Server.Model3D
                 MonitorLog.LogToMonitor(monitorItem);
                 OpenDialog(ex.Message, $"{Application.Current.Resources["exError"]}");
             }
-        
+
+        }
+
+        /// <summary>
+        /// Restores the saved camera position/direction from Settings onto the VM properties
+        /// and re-applies the current telescope axis rotation. Does NOT reload the .obj model.
+        /// The VM property changes trigger SyncCameraFromViewModel in HelixViewport3D.xaml.cs.
+        /// </summary>
+        private void RefreshView()
+        {
+            // Restore camera from persisted settings slot 1 (Model3Dvm always uses slot 1).
+            LookDirection = Settings.Settings.ModelLookDirection1;
+            UpDirection   = Settings.Settings.ModelUpDirection1;
+            Position      = Settings.Settings.ModelPosition1;
+
+            // Re-apply telescope rotation to current axis positions.
+            Rotate();
+            SetPierSideIndicator();
         }
 
         /// <summary>

--- a/GS.Server/SkyTelescope/SkyTelescopeVM.cs
+++ b/GS.Server/SkyTelescope/SkyTelescopeVM.cs
@@ -3000,11 +3000,12 @@ namespace GS.Server.SkyTelescope
                 var modelVm = ModelVm.Model1Vm;
                 modelVm.WinHeight = 320;
                 modelVm.WinWidth = 250;
+                // Set camera values BEFORE Show() so SyncCameraFromViewModel fires with correct data.
+                modelVm.CameraIndex = 2;
                 modelVm.Position = Position;
                 modelVm.LookDirection = LookDirection;
                 modelVm.UpDirection = UpDirection;
                 modelVm.ImageFile = ImageFile;
-                modelVm.CameraIndex = 2;
                 bWin.Show();
             }
             catch (Exception ex)
@@ -3042,22 +3043,17 @@ namespace GS.Server.SkyTelescope
         {
             try
             {
-                if (Numbers.IsNaNVector3D(LookDirection) || Numbers.Is0Vector3D(LookDirection))
-                {
+                // Repair persisted settings if they are invalid before restoring.
+                if (Numbers.IsNaNVector3D(Settings.Settings.ModelLookDirection2) || Numbers.Is0Vector3D(Settings.Settings.ModelLookDirection2))
                     Settings.Settings.ModelLookDirection2 = new Vector3D(-900, -1100, -400);
-                }
 
-                if (Numbers.IsNaNVector3D(UpDirection) || Numbers.Is0Vector3D(UpDirection))
-                {
+                if (Numbers.IsNaNVector3D(Settings.Settings.ModelUpDirection2) || Numbers.Is0Vector3D(Settings.Settings.ModelUpDirection2))
                     Settings.Settings.ModelUpDirection2 = new Vector3D(.35, .43, .82);
-                }
 
-                if (Numbers.IsNaNPoint3D(Position) || Numbers.Is0Point3D(Position))
-                {
+                if (Numbers.IsNaNPoint3D(Settings.Settings.ModelPosition2) || Numbers.Is0Point3D(Settings.Settings.ModelPosition2))
                     Settings.Settings.ModelPosition2 = new Point3D(900, 1100, 800);
-                }
 
-                LoadTelescopeModel();
+                RefreshView();
             }
             catch (Exception ex)
             {
@@ -3114,6 +3110,23 @@ namespace GS.Server.SkyTelescope
                 MonitorLog.LogToMonitor(monitorItem);
                 OpenDialog(ex.Message, $"{Application.Current.Resources["exError"]}");
             }
+        }
+
+        /// <summary>
+        /// Restores the saved camera position/direction from Settings onto the VM properties
+        /// and re-applies the current telescope axis rotation. Does NOT reload the .obj model.
+        /// The VM property changes trigger SyncCameraFromViewModel in HelixViewport3D.xaml.cs.
+        /// </summary>
+        private void RefreshView()
+        {
+            // Restore camera from persisted settings slot 2 (SkyTelescopeVm always uses slot 2).
+            LookDirection = Settings.Settings.ModelLookDirection2;
+            UpDirection   = Settings.Settings.ModelUpDirection2;
+            Position      = Settings.Settings.ModelPosition2;
+
+            // Re-apply telescope rotation to current axis positions.
+            Rotate();
+            SetPierSideIndicator();
         }
 
         #endregion

--- a/GS.Server/Windows/ModelVM.cs
+++ b/GS.Server/Windows/ModelVM.cs
@@ -926,7 +926,22 @@ namespace GS.Server.Windows
         {
             try
             {
-                LoadTelescopeModel();
+                // Repair persisted settings for both slots in case of NaN/zero.
+                if (Numbers.IsNaNVector3D(Settings.Settings.ModelLookDirection1) || Numbers.Is0Vector3D(Settings.Settings.ModelLookDirection1))
+                    Settings.Settings.ModelLookDirection1 = new Vector3D(-900, -1100, -400);
+                if (Numbers.IsNaNVector3D(Settings.Settings.ModelUpDirection1) || Numbers.Is0Vector3D(Settings.Settings.ModelUpDirection1))
+                    Settings.Settings.ModelUpDirection1 = new Vector3D(.35, .43, .82);
+                if (Numbers.IsNaNPoint3D(Settings.Settings.ModelPosition1) || Numbers.Is0Point3D(Settings.Settings.ModelPosition1))
+                    Settings.Settings.ModelPosition1 = new Point3D(900, 1100, 800);
+
+                if (Numbers.IsNaNVector3D(Settings.Settings.ModelLookDirection2) || Numbers.Is0Vector3D(Settings.Settings.ModelLookDirection2))
+                    Settings.Settings.ModelLookDirection2 = new Vector3D(-900, -1100, -400);
+                if (Numbers.IsNaNVector3D(Settings.Settings.ModelUpDirection2) || Numbers.Is0Vector3D(Settings.Settings.ModelUpDirection2))
+                    Settings.Settings.ModelUpDirection2 = new Vector3D(.35, .43, .82);
+                if (Numbers.IsNaNPoint3D(Settings.Settings.ModelPosition2) || Numbers.Is0Point3D(Settings.Settings.ModelPosition2))
+                    Settings.Settings.ModelPosition2 = new Point3D(900, 1100, 800);
+
+                RefreshView();
             }
             catch (Exception ex)
             {
@@ -983,6 +998,31 @@ namespace GS.Server.Windows
                 MonitorLog.LogToMonitor(monitorItem);
                 OpenDialog(ex.Message, $"{Application.Current.Resources["exError"]}");
             }
+        }
+
+        /// <summary>
+        /// Restores the saved camera position/direction from Settings onto the VM properties
+        /// and re-applies the current telescope axis rotation. Does NOT reload the .obj model.
+        /// The VM property changes trigger SyncCameraFromViewModel in HelixViewport3D.xaml.cs.
+        /// </summary>
+        private void RefreshView()
+        {
+            if (CameraIndex == 1)
+            {
+                LookDirection = Settings.Settings.ModelLookDirection1;
+                UpDirection   = Settings.Settings.ModelUpDirection1;
+                Position      = Settings.Settings.ModelPosition1;
+            }
+            else
+            {
+                LookDirection = Settings.Settings.ModelLookDirection2;
+                UpDirection   = Settings.Settings.ModelUpDirection2;
+                Position      = Settings.Settings.ModelPosition2;
+            }
+
+            // Re-apply telescope rotation to current axis positions.
+            Rotate();
+            SetPierSideIndicator();
         }
         #endregion
 


### PR DESCRIPTION
- Fixes reset view failures, freezable binding and camera-sync issues in HelixViewport3D, improves camera restore behaviour in model VMs, corrects camera-index/settings bugs
- Adds AutoHome sensor vs. home position diagnostic logging
- Version bumped to 1.2.2.2.